### PR TITLE
usharpのビルドエラーを修正

### DIFF
--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierImage.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierImage.cs
@@ -1,8 +1,7 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_EDITOR
 using UnityEditor;
-#endif
 
 namespace jp.ootr.common.ColorSchema
 {
@@ -13,14 +12,11 @@ namespace jp.ootr.common.ColorSchema
         {
             var image = gameObject.GetComponent<Image>();
             if (image == null) return;
-#if UNITY_EDITOR
             var so = new SerializedObject(image);
             so.Update();
             so.FindProperty("m_Color").colorValue = color;
             so.ApplyModifiedProperties();
-#else
-            image.color = color;
-#endif
         }
     }
 }
+#endif

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierInterface.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierInterface.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 
 namespace jp.ootr.common.ColorSchema
 {
@@ -8,3 +9,4 @@ namespace jp.ootr.common.ColorSchema
         void ApplyColor(Color color);
     }
 }
+#endif

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierRawImage.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierRawImage.cs
@@ -1,8 +1,7 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_EDITOR
 using UnityEditor;
-#endif
 
 namespace jp.ootr.common.ColorSchema
 {
@@ -13,14 +12,11 @@ namespace jp.ootr.common.ColorSchema
         {
             var image = gameObject.GetComponent<RawImage>();
             if (image == null) return;
-#if UNITY_EDITOR
             var so = new SerializedObject(image);
             so.Update();
             so.FindProperty("m_Color").colorValue = color;
             so.ApplyModifiedProperties();
-#else
-            image.color = color;
-#endif
         }
     }
 }
+#endif

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierText.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierText.cs
@@ -12,7 +12,7 @@ namespace jp.ootr.common.ColorSchema
         {
             var text = gameObject.GetComponent<Text>();
             if (text == null) return;
-           var so = new SerializedObject(text);
+            var so = new SerializedObject(text);
             so.Update();
             so.FindProperty("m_Color").colorValue = color;
             so.ApplyModifiedProperties();

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierText.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierText.cs
@@ -1,8 +1,7 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_EDITOR
 using UnityEditor;
-#endif
 
 namespace jp.ootr.common.ColorSchema
 {
@@ -13,14 +12,11 @@ namespace jp.ootr.common.ColorSchema
         {
             var text = gameObject.GetComponent<Text>();
             if (text == null) return;
-#if UNITY_EDITOR
-            var so = new SerializedObject(text);
+           var so = new SerializedObject(text);
             so.Update();
             so.FindProperty("m_Color").colorValue = color;
             so.ApplyModifiedProperties();
-#else
-            text.color = color;
-#endif
         }
     }
 }
+#endif

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierTextMeshProUGUI.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierTextMeshProUGUI.cs
@@ -1,8 +1,7 @@
-﻿using TMPro;
+﻿#if UNITY_EDITOR
+using TMPro;
 using UnityEngine;
-#if UNITY_EDITOR
 using UnityEditor;
-#endif
 
 namespace jp.ootr.common.ColorSchema
 {
@@ -13,15 +12,12 @@ namespace jp.ootr.common.ColorSchema
         {
             var text = gameObject.GetComponent<TextMeshProUGUI>();
             if (text == null) return;
-#if UNITY_EDITOR
             var so = new SerializedObject(text);
             so.Update();
             so.FindProperty("m_fontColor").colorValue = color;
             so.FindProperty("m_faceColor").colorValue = color;
             so.ApplyModifiedProperties();
-#else
-            text.color = color;
-#endif
         }
     }
 }
+#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Color schema appliers are now editor-only, so color application tooling is available in the editor but not in runtime builds.
  * Unified the color-application approach across applier types for consistent editor behavior and simpler maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->