### PR TITLE
l10n用のエディターを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs grep:*)"
+    ]
+  }
+}

--- a/Runtime/Editor/BaseEditor.cs
+++ b/Runtime/Editor/BaseEditor.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using jp.ootr.common.ColorSchema;
 using jp.ootr.common.Localization;
@@ -102,6 +102,18 @@ namespace jp.ootr.common.Editor
                 value = false
             };
 
+            var openLocalizationBtn = new Button(() =>
+            {
+                var bc = target as BaseClass;
+                if (bc != null)
+                    LocalizationWindow.ShowWindowWithTarget(bc);
+                else
+                    Debug.LogWarning("Target is not BaseClass.");
+            })
+            {
+                text = "Open Localization Window"
+            };
+            foldout.Add(openLocalizationBtn);
             foldout.Add(new IMGUIContainer(base.OnInspectorGUI));
             Root.Add(foldout);
         }

--- a/Runtime/Editor/LocalizationApplierEditor.cs
+++ b/Runtime/Editor/LocalizationApplierEditor.cs
@@ -49,7 +49,6 @@ namespace jp.ootr.common.Editor
                     root.Add(new PropertyField(prop));
             } while (prop.NextVisible(false));
 
-            serializedObject.ApplyModifiedProperties();
             return root;
         }
 

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -136,12 +136,13 @@ namespace jp.ootr.common.Editor
             var so = new SerializedObject(_target);
             var keysProp = so.FindProperty("localizationKeys");
             var valuesProp = so.FindProperty("localizationValues");
-            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
-                return;
 
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
             _explicitlyAddedLanguages.Clear();
+
+            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+                return;
 
             var keyOrder = new List<string>();
             var seen = new HashSet<string>();
@@ -485,7 +486,7 @@ namespace jp.ootr.common.Editor
             }
 
             Undo.RecordObject(_target, "Edit Localization Data");
-            so.ApplyModifiedProperties();
+            so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
         }
     }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -34,6 +34,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private float _keyColumnWidth = DefaultKeyColumnWidth;
         [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
         [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
+        [SerializeField] private BaseClass _lastLoadedTarget;
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
         private bool _malformedDataOnLoad;
         private bool _isDirty;
@@ -182,9 +183,10 @@ namespace jp.ootr.common.Editor
             }
 
             _malformedDataOnLoad = false;
+            if (_target != _lastLoadedTarget)
+                _explicitlyAddedLanguages.Clear();
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
-            _explicitlyAddedLanguages.Clear();
             _loadedLanguages.Clear();
 
             var keyOrder = new List<string>();
@@ -218,6 +220,7 @@ namespace jp.ootr.common.Editor
             }
 
             _logicalKeys = keyOrder;
+            _lastLoadedTarget = _target;
             _isDirty = false;
         }
 
@@ -241,9 +244,9 @@ namespace jp.ootr.common.Editor
             foreach (var lang in _explicitlyAddedLanguages)
                 hasValue.Add(lang);
 
-            // いずれのキーにも値がない場合は全言語を表示（新規入力用）
+            // いずれのキーにも値がない場合は En のみ表示（他は Add Language で追加）
             if (hasValue.Count == 0 && _logicalKeys.Count > 0)
-                return new List<Localization.Language>(AllLanguages);
+                return new List<Localization.Language> { Localization.Language.En };
             return AllLanguages.Where(hasValue.Contains).ToList();
         }
 
@@ -565,6 +568,26 @@ namespace jp.ootr.common.Editor
                 return;
             }
 
+            if (_loadedLanguages.Count == 0)
+            {
+                var soPre = new SerializedObject(_target);
+                var keysPropPre = soPre.FindProperty("localizationKeys");
+                if (keysPropPre != null)
+                {
+                    for (var i = 0; i < keysPropPre.arraySize; i++)
+                    {
+                        var fullKey = keysPropPre.GetArrayElementAtIndex(i).stringValue;
+                        if (string.IsNullOrEmpty(fullKey)) continue;
+                        var dot = fullKey.IndexOf('.');
+                        if (dot < 0) continue;
+                        var langStr = fullKey.Substring(0, dot);
+                        var lang = FromStr(langStr);
+                        if (lang != null)
+                            _loadedLanguages.Add(lang.Value);
+                    }
+                }
+            }
+
             var saveLangs = AllLanguages
                 .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l)
                     || _keyToLangToValue.Values.Any(d => d.TryGetValue(l, out var v) && !string.IsNullOrEmpty(v)))
@@ -576,8 +599,15 @@ namespace jp.ootr.common.Editor
                 foreach (var lang in saveLangs)
                 {
                     var value = dict.TryGetValue(lang, out var v) ? v : "";
-                    var fullKey = $"{LanguageUtils.ToStr(lang)}.{key}";
-                    pairs.Add((fullKey, value));
+                    var langPrefix = LanguageUtils.ToStr(lang);
+                    if (langPrefix == "en" && lang != Localization.Language.En)
+                    {
+                        Debug.LogError($"ToStr returned 'en' for unexpected language {lang}; skipping to avoid data corruption.");
+                    }
+                    else
+                    {
+                        pairs.Add(($"{langPrefix}.{key}", value));
+                    }
                 }
             }
 

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -396,7 +396,7 @@ namespace jp.ootr.common.Editor
             table.style.flexDirection = FlexDirection.Column;
             table.style.flexShrink = 0;
             var totalWidth = _columnWidths.Sum();
-            table.style.minWidth = totalWidth;
+            table.style.minWidth = totalWidth + 20f;
 
             var keyColumnCells = new List<VisualElement>();
             _columnCellRefs.Add(keyColumnCells);
@@ -412,6 +412,12 @@ namespace jp.ootr.common.Editor
             headerRow.style.backgroundColor = new StyleColor(HeaderBackground);
             headerRow.style.borderBottomWidth = 1;
             headerRow.style.borderBottomColor = new StyleColor(HeaderBorder);
+
+            var deletePlaceholder = new VisualElement();
+            deletePlaceholder.style.width = 20;
+            deletePlaceholder.style.minWidth = 20;
+            deletePlaceholder.style.flexShrink = 0;
+            headerRow.Add(deletePlaceholder);
 
             var keyHeaderCell = CreateHeaderCell("Key", 0);
             headerRow.Add(keyHeaderCell);
@@ -445,6 +451,11 @@ namespace jp.ootr.common.Editor
                 }) { text = "✕" };
                 deleteBtn.style.width = 20;
                 deleteBtn.style.minWidth = 20;
+                deleteBtn.style.maxWidth = 20;
+                deleteBtn.style.paddingLeft = 0;
+                deleteBtn.style.paddingRight = 0;
+                deleteBtn.style.marginLeft = 0;
+                deleteBtn.style.marginRight = 0;
                 deleteBtn.style.flexShrink = 0;
                 row.Add(deleteBtn);
 

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -35,6 +35,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
         [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
+        private bool _malformedDataOnLoad;
 
         private DropdownField _langDropdown;
 
@@ -107,24 +108,7 @@ namespace jp.ootr.common.Editor
         }
 
         private static readonly Dictionary<string, Localization.Language> StrToLang =
-            new Dictionary<string, Localization.Language>
-            {
-                { "en", Localization.Language.En },
-                { "fr", Localization.Language.Fr },
-                { "es", Localization.Language.Es },
-                { "it", Localization.Language.It },
-                { "ko", Localization.Language.Ko },
-                { "de", Localization.Language.De },
-                { "ja", Localization.Language.Ja },
-                { "pl", Localization.Language.Pl },
-                { "ru", Localization.Language.Ru },
-                { "pt_BR", Localization.Language.PtBR },
-                { "zh_CN", Localization.Language.ZhCn },
-                { "zh_HK", Localization.Language.ZhHk },
-                { "he", Localization.Language.He },
-                { "tok", Localization.Language.Tok },
-                { "uk", Localization.Language.Uk },
-            };
+            AllLanguages.ToDictionary(l => LanguageUtils.ToStr(l));
 
         private static Localization.Language? FromStr(string langStr)
         {
@@ -157,6 +141,7 @@ namespace jp.ootr.common.Editor
                 _keyToLangToValue.Clear();
                 _explicitlyAddedLanguages.Clear();
                 _loadedLanguages.Clear();
+                _malformedDataOnLoad = false;
                 return;
             }
 
@@ -165,8 +150,12 @@ namespace jp.ootr.common.Editor
             var valuesProp = so.FindProperty("localizationValues");
 
             if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+            {
+                _malformedDataOnLoad = true;
                 return;
+            }
 
+            _malformedDataOnLoad = false;
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
             _explicitlyAddedLanguages.Clear();
@@ -517,6 +506,11 @@ namespace jp.ootr.common.Editor
         private void OnSave()
         {
             if (_target == null) return;
+            if (_malformedDataOnLoad)
+            {
+                Debug.LogError("Cannot save: localization data could not be loaded (malformed or mismatched arrays).");
+                return;
+            }
 
             var saveLangs = AllLanguages
                 .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l)

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -488,9 +488,9 @@ namespace jp.ootr.common.Editor
                 var idx = rowIndex;
                 var deleteBtn = new Button(() =>
                 {
-                    var liveKey = _logicalKeys[idx];
+                    if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                     _logicalKeys.RemoveAt(idx);
-                    _keyToLangToValue.Remove(liveKey);
+                    _keyToLangToValue.Remove(logicalKey);
                     _isDirty = true;
                     hasUnsavedChanges = true;
                     saveChangesMessage = "You have unsaved localization changes. Save before closing?";
@@ -511,6 +511,7 @@ namespace jp.ootr.common.Editor
                 keyColumnCells.Add(keyField);
                 void ApplyOrRevertKeyRename()
                 {
+                    if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                     var oldKey = _logicalKeys[idx];
                     var newKey = keyField.value?.Trim() ?? "";
                     if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey || _keyToLangToValue.ContainsKey(newKey))
@@ -521,6 +522,7 @@ namespace jp.ootr.common.Editor
                     _keyToLangToValue[newKey] = _keyToLangToValue[oldKey];
                     _keyToLangToValue.Remove(oldKey);
                     _logicalKeys[idx] = newKey;
+                    logicalKey = newKey;
                     keyField.SetValueWithoutNotify(newKey);
                     _isDirty = true;
                     hasUnsavedChanges = true;
@@ -546,6 +548,7 @@ namespace jp.ootr.common.Editor
                     _columnCellRefs[c + 1].Add(tf);
                     tf.RegisterValueChangedCallback(evt =>
                     {
+                        if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                         var key = _logicalKeys[idx];
                         if (!_keyToLangToValue.TryGetValue(key, out var d))
                         {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -34,6 +34,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private float _keyColumnWidth = DefaultKeyColumnWidth;
         [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
         [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
+        private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
 
         private DropdownField _langDropdown;
 
@@ -100,7 +101,7 @@ namespace jp.ootr.common.Editor
             wnd.titleContent = new GUIContent("Localization");
             wnd._target = target;
             if (wnd._targetField != null)
-                wnd._targetField.value = target;
+                wnd._targetField.SetValueWithoutNotify(target);
             if (wnd._tableContainer != null)
                 wnd.ReloadTable();
         }
@@ -130,6 +131,7 @@ namespace jp.ootr.common.Editor
                 _logicalKeys.Clear();
                 _keyToLangToValue.Clear();
                 _explicitlyAddedLanguages.Clear();
+                _loadedLanguages.Clear();
                 return;
             }
 
@@ -140,6 +142,7 @@ namespace jp.ootr.common.Editor
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
             _explicitlyAddedLanguages.Clear();
+            _loadedLanguages.Clear();
 
             if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
                 return;
@@ -159,6 +162,7 @@ namespace jp.ootr.common.Editor
                 var logicalKey = fullKey.Substring(dot + 1);
                 var lang = LanguageUtils.FromStr(langStr);
                 if (lang == null) continue;
+                _loadedLanguages.Add(lang.Value);
 
                 if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
                 {
@@ -222,7 +226,6 @@ namespace jp.ootr.common.Editor
             if (!_explicitlyAddedLanguages.Contains(lang))
                 _explicitlyAddedLanguages.Add(lang);
             ReloadTable(loadFromTarget: false);
-            UpdateLangDropdownChoices();
         }
 
         private float GetLangColumnWidth(Localization.Language lang)
@@ -458,13 +461,14 @@ namespace jp.ootr.common.Editor
         {
             if (_target == null) return;
 
-            var visibleLangs = GetVisibleLanguages();
+            var saveLangs = AllLanguages
+                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l))
+                .ToList();
             var pairs = new List<(string fullKey, string value)>();
             foreach (var key in _logicalKeys)
             {
-                if (!_keyToLangToValue.TryGetValue(key, out var dict))
-                    dict = new Dictionary<Localization.Language, string>();
-                foreach (var lang in visibleLangs)
+                var dict = _keyToLangToValue[key];
+                foreach (var lang in saveLangs)
                 {
                     var value = dict.TryGetValue(lang, out var v) ? v : "";
                     var fullKey = $"{LanguageUtils.ToStr(lang)}.{key}";

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -36,6 +36,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
         private bool _malformedDataOnLoad;
+        private bool _isDirty;
 
         private DropdownField _langDropdown;
 
@@ -128,6 +129,15 @@ namespace jp.ootr.common.Editor
             };
             _targetField.RegisterValueChangedCallback(evt =>
             {
+                if (_isDirty && !EditorUtility.DisplayDialog(
+                        "Unsaved Changes",
+                        "You have unsaved localization changes. Discard them?",
+                        "Discard", "Cancel"))
+                {
+                    _targetField.SetValueWithoutNotify(_target);
+                    return;
+                }
+                _isDirty = false;
                 _target = (BaseClass)evt.newValue;
                 ReloadTable();
             });
@@ -144,6 +154,7 @@ namespace jp.ootr.common.Editor
                 _explicitlyAddedLanguages.Clear();
                 _loadedLanguages.Clear();
                 _malformedDataOnLoad = false;
+                _isDirty = false;
                 return;
             }
 
@@ -156,6 +167,7 @@ namespace jp.ootr.common.Editor
                 _malformedDataOnLoad = true;
                 _logicalKeys.Clear();
                 _keyToLangToValue.Clear();
+                _isDirty = false;
                 return;
             }
 
@@ -196,6 +208,7 @@ namespace jp.ootr.common.Editor
             }
 
             _logicalKeys = keyOrder;
+            _isDirty = false;
         }
 
         /// <summary>
@@ -244,6 +257,7 @@ namespace jp.ootr.common.Editor
             if (!Enum.TryParse<Localization.Language>(_langDropdown.value, out var lang)) return;
             if (!_explicitlyAddedLanguages.Contains(lang))
                 _explicitlyAddedLanguages.Add(lang);
+            _isDirty = true;
             ReloadTable(loadFromTarget: false);
         }
 
@@ -447,6 +461,7 @@ namespace jp.ootr.common.Editor
                     var liveKey = _logicalKeys[idx];
                     _logicalKeys.RemoveAt(idx);
                     _keyToLangToValue.Remove(liveKey);
+                    _isDirty = true;
                     ReloadTable(loadFromTarget: false);
                 }) { text = "✕" };
                 deleteBtn.style.width = 20;
@@ -462,10 +477,10 @@ namespace jp.ootr.common.Editor
                 var keyField = new TextField { value = logicalKey };
                 SetCellStyle(keyField, _columnWidths[0]);
                 keyColumnCells.Add(keyField);
-                keyField.RegisterValueChangedCallback(evt =>
+                void ApplyOrRevertKeyRename()
                 {
                     var oldKey = _logicalKeys[idx];
-                    var newKey = evt.newValue?.Trim() ?? "";
+                    var newKey = keyField.value?.Trim() ?? "";
                     if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey || _keyToLangToValue.ContainsKey(newKey))
                     {
                         keyField.SetValueWithoutNotify(oldKey);
@@ -475,6 +490,16 @@ namespace jp.ootr.common.Editor
                     _keyToLangToValue.Remove(oldKey);
                     _logicalKeys[idx] = newKey;
                     keyField.SetValueWithoutNotify(newKey);
+                    _isDirty = true;
+                }
+                keyField.RegisterCallback<FocusOutEvent>(evt => ApplyOrRevertKeyRename());
+                keyField.RegisterCallback<KeyDownEvent>(evt =>
+                {
+                    if (evt.keyCode == KeyCode.Return || evt.keyCode == KeyCode.KeypadEnter)
+                    {
+                        ApplyOrRevertKeyRename();
+                        evt.PreventDefault();
+                    }
                 });
                 row.Add(keyField);
 
@@ -494,6 +519,7 @@ namespace jp.ootr.common.Editor
                             _keyToLangToValue[key] = d;
                         }
                         d[lang1] = evt.newValue;
+                        _isDirty = true;
                     });
                     row.Add(tf);
                 }
@@ -516,6 +542,7 @@ namespace jp.ootr.common.Editor
                 name = $"{baseName}_{++c}";
             _logicalKeys.Add(name);
             _keyToLangToValue[name] = new Dictionary<Localization.Language, string>();
+            _isDirty = true;
             ReloadTable(loadFromTarget: false);
         }
 
@@ -560,6 +587,7 @@ namespace jp.ootr.common.Editor
 
             so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
+            _isDirty = false;
         }
     }
 }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -108,7 +108,9 @@ namespace jp.ootr.common.Editor
         }
 
         private static readonly Dictionary<string, Localization.Language> StrToLang =
-            AllLanguages.ToDictionary(l => LanguageUtils.ToStr(l));
+            AllLanguages
+                .GroupBy(l => LanguageUtils.ToStr(l))
+                .ToDictionary(g => g.Key, g => g.First());
 
         private static Localization.Language? FromStr(string langStr)
         {
@@ -460,6 +462,7 @@ namespace jp.ootr.common.Editor
                     _keyToLangToValue[newKey] = _keyToLangToValue[oldKey];
                     _keyToLangToValue.Remove(oldKey);
                     _logicalKeys[idx] = newKey;
+                    keyField.SetValueWithoutNotify(newKey);
                 });
                 row.Add(keyField);
 

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -106,6 +106,31 @@ namespace jp.ootr.common.Editor
                 wnd.ReloadTable();
         }
 
+        private static readonly Dictionary<string, Localization.Language> StrToLang =
+            new Dictionary<string, Localization.Language>
+            {
+                { "en", Localization.Language.En },
+                { "fr", Localization.Language.Fr },
+                { "es", Localization.Language.Es },
+                { "it", Localization.Language.It },
+                { "ko", Localization.Language.Ko },
+                { "de", Localization.Language.De },
+                { "ja", Localization.Language.Ja },
+                { "pl", Localization.Language.Pl },
+                { "ru", Localization.Language.Ru },
+                { "pt_BR", Localization.Language.PtBR },
+                { "zh_CN", Localization.Language.ZhCn },
+                { "zh_HK", Localization.Language.ZhHk },
+                { "he", Localization.Language.He },
+                { "tok", Localization.Language.Tok },
+                { "uk", Localization.Language.Uk },
+            };
+
+        private static Localization.Language? FromStr(string langStr)
+        {
+            return StrToLang.TryGetValue(langStr, out var lang) ? lang : (Localization.Language?)null;
+        }
+
         private VisualElement GetTargetPicker()
         {
             var root = new VisualElement();
@@ -160,7 +185,7 @@ namespace jp.ootr.common.Editor
                 if (dot < 0) continue;
                 var langStr = fullKey.Substring(0, dot);
                 var logicalKey = fullKey.Substring(dot + 1);
-                var lang = LanguageUtils.FromStr(langStr);
+                var lang = FromStr(langStr);
                 if (lang == null) continue;
                 _loadedLanguages.Add(lang.Value);
 
@@ -413,8 +438,9 @@ namespace jp.ootr.common.Editor
                 var idx = rowIndex;
                 var deleteBtn = new Button(() =>
                 {
+                    var liveKey = _logicalKeys[idx];
                     _logicalKeys.RemoveAt(idx);
-                    _keyToLangToValue.Remove(logicalKey);
+                    _keyToLangToValue.Remove(liveKey);
                     ReloadTable(loadFromTarget: false);
                 }) { text = "✕" };
                 deleteBtn.style.width = 20;

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -94,6 +94,8 @@ namespace jp.ootr.common.Editor
 
             if (_target != null)
                 ReloadTable();
+            else
+                hasUnsavedChanges = false;
 
             rootVisualElement.Add(root);
         }
@@ -427,6 +429,9 @@ namespace jp.ootr.common.Editor
                 c.style.minWidth = width;
                 c.style.maxWidth = width;
             }
+
+            if (_tableContainer?.contentContainer?.Children().FirstOrDefault() is VisualElement table)
+                table.style.minWidth = _columnWidths.Sum() + 20f;
         }
 
         /// <param name="loadFromTarget">true のとき SerializedObject から再読み込み。Add Key 時は false でメモリ上のデータのみでテーブル再描画。</param>
@@ -646,6 +651,7 @@ namespace jp.ootr.common.Editor
                 foreach (var lang in saveLangs)
                 {
                     var value = dict.TryGetValue(lang, out var v) ? v : "";
+                    if (string.IsNullOrEmpty(value) && !_loadedLanguages.Contains(lang)) continue;
                     var langPrefix = LanguageUtils.ToStr(lang);
                     if (langPrefix == "en" && lang != Localization.Language.En)
                     {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -182,64 +182,71 @@ namespace jp.ootr.common.Editor
                 return;
             }
 
-            using var so = new SerializedObject(_target);
-            var keysProp = so.FindProperty("localizationKeys");
-            var valuesProp = so.FindProperty("localizationValues");
-
-            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+            var so = new SerializedObject(_target);
+            try
             {
-                _malformedDataOnLoad = true;
+                var keysProp = so.FindProperty("localizationKeys");
+                var valuesProp = so.FindProperty("localizationValues");
+
+                if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+                {
+                    _malformedDataOnLoad = true;
+                    _logicalKeys.Clear();
+                    _keyToLangToValue.Clear();
+                    _loadedLanguages.Clear();
+                    _explicitlyAddedLanguages.Clear();
+                    _isDirty = false;
+                    hasUnsavedChanges = false;
+                    return;
+                }
+
+                _malformedDataOnLoad = false;
+                if (_target != _lastLoadedTarget)
+                    _explicitlyAddedLanguages.Clear();
                 _logicalKeys.Clear();
                 _keyToLangToValue.Clear();
                 _loadedLanguages.Clear();
-                _explicitlyAddedLanguages.Clear();
-                _isDirty = false;
-                hasUnsavedChanges = false;
-                return;
-            }
 
-            _malformedDataOnLoad = false;
-            if (_target != _lastLoadedTarget)
-                _explicitlyAddedLanguages.Clear();
-            _logicalKeys.Clear();
-            _keyToLangToValue.Clear();
-            _loadedLanguages.Clear();
+                var keyOrder = new List<string>();
+                var seen = new HashSet<string>();
 
-            var keyOrder = new List<string>();
-            var seen = new HashSet<string>();
-
-            for (var i = 0; i < keysProp.arraySize; i++)
-            {
-                var fullKey = keysProp.GetArrayElementAtIndex(i).stringValue;
-                var value = valuesProp.GetArrayElementAtIndex(i).stringValue ?? "";
-                if (string.IsNullOrEmpty(fullKey)) continue;
-
-                var dot = fullKey.IndexOf('.');
-                if (dot < 0) continue;
-                var langStr = fullKey.Substring(0, dot);
-                var logicalKey = fullKey.Substring(dot + 1);
-                var lang = FromStr(langStr);
-                if (lang == null) continue;
-                if (!string.IsNullOrEmpty(value))
-                    _loadedLanguages.Add(lang.Value);
-
-                if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
+                for (var i = 0; i < keysProp.arraySize; i++)
                 {
-                    _keyToLangToValue[logicalKey] = dict = new Dictionary<Localization.Language, string>();
-                    if (!seen.Contains(logicalKey))
+                    var fullKey = keysProp.GetArrayElementAtIndex(i).stringValue;
+                    var value = valuesProp.GetArrayElementAtIndex(i).stringValue ?? "";
+                    if (string.IsNullOrEmpty(fullKey)) continue;
+
+                    var dot = fullKey.IndexOf('.');
+                    if (dot < 0) continue;
+                    var langStr = fullKey.Substring(0, dot);
+                    var logicalKey = fullKey.Substring(dot + 1);
+                    var lang = FromStr(langStr);
+                    if (lang == null) continue;
+                    if (!string.IsNullOrEmpty(value))
+                        _loadedLanguages.Add(lang.Value);
+
+                    if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
                     {
-                        seen.Add(logicalKey);
-                        keyOrder.Add(logicalKey);
+                        _keyToLangToValue[logicalKey] = dict = new Dictionary<Localization.Language, string>();
+                        if (!seen.Contains(logicalKey))
+                        {
+                            seen.Add(logicalKey);
+                            keyOrder.Add(logicalKey);
+                        }
                     }
+
+                    dict[lang.Value] = value;
                 }
 
-                dict[lang.Value] = value;
+                _logicalKeys = keyOrder;
+                _lastLoadedTarget = _target;
+                _isDirty = false;
+                hasUnsavedChanges = false;
             }
-
-            _logicalKeys = keyOrder;
-            _lastLoadedTarget = _target;
-            _isDirty = false;
-            hasUnsavedChanges = false;
+            finally
+            {
+                so.Dispose();
+            }
         }
 
         /// <summary>
@@ -603,8 +610,10 @@ namespace jp.ootr.common.Editor
             ReloadTable(loadFromTarget: false);
             _tableContainer.schedule.Execute(() =>
             {
-                var last = _tableContainer.contentContainer.Children().LastOrDefault();
-                if (last != null) _tableContainer.ScrollTo(last);
+                var tableEl = _tableContainer.contentContainer.Children().LastOrDefault();
+                if (tableEl == null) return;
+                var lastRow = tableEl.Children().LastOrDefault();
+                if (lastRow != null && _tableContainer is ScrollView sv) sv.ScrollTo(lastRow);
             });
         }
 
@@ -649,20 +658,28 @@ namespace jp.ootr.common.Editor
                 }
             }
 
-            Undo.RecordObject(_target, "Edit Localization Data");
-            using var so = new SerializedObject(_target);
-            var keysProp = so.FindProperty("localizationKeys");
-            var valuesProp = so.FindProperty("localizationValues");
-            if (keysProp == null || valuesProp == null) return;
-            keysProp.arraySize = pairs.Count;
-            valuesProp.arraySize = pairs.Count;
-            for (var i = 0; i < pairs.Count; i++)
+            var so = new SerializedObject(_target);
+            try
             {
-                keysProp.GetArrayElementAtIndex(i).stringValue = pairs[i].fullKey;
-                valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
-            }
+                var keysProp = so.FindProperty("localizationKeys");
+                var valuesProp = so.FindProperty("localizationValues");
+                if (keysProp == null || valuesProp == null) return;
 
-            so.ApplyModifiedPropertiesWithoutUndo();
+                Undo.RecordObject(_target, "Edit Localization Data");
+                keysProp.arraySize = pairs.Count;
+                valuesProp.arraySize = pairs.Count;
+                for (var i = 0; i < pairs.Count; i++)
+                {
+                    keysProp.GetArrayElementAtIndex(i).stringValue = pairs[i].fullKey;
+                    valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
+                }
+
+                so.ApplyModifiedPropertiesWithoutUndo();
+            }
+            finally
+            {
+                so.Dispose();
+            }
             EditorUtility.SetDirty(_target);
             if (!EditorUtility.IsPersistent(_target))
             {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -258,8 +258,11 @@ namespace jp.ootr.common.Editor
                 .Where(l => !current.Contains(l))
                 .Select(l => LanguageUtils.ToStr(l))
                 .ToList();
+            var previousValue = _langDropdown.value;
             _langDropdown.choices = choices;
-            _langDropdown.value = choices.Count > 0 ? choices[0] : "";
+            _langDropdown.value = (choices.Count > 0 && choices.Contains(previousValue))
+                ? previousValue
+                : (choices.Count > 0 ? choices[0] : "");
         }
 
         private void OnAddLanguage()
@@ -452,7 +455,7 @@ namespace jp.ootr.common.Editor
 
             for (var c = 0; c < _visibleLangsSnapshot.Count; c++)
             {
-                var headerCell = CreateHeaderCell(_visibleLangsSnapshot[c].ToString(), c + 1);
+                var headerCell = CreateHeaderCell(LanguageUtils.ToStr(_visibleLangsSnapshot[c]), c + 1);
                 headerRow.Add(headerCell);
             }
             table.Add(headerRow);

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -43,14 +43,17 @@ namespace jp.ootr.common.Editor
         private int _resizingColumnIndex = -1;
         private float _resizeStartX;
         private float _resizeStartWidth;
-        private EventCallback<MouseMoveEvent> _resizeMoveHandler;
-        private EventCallback<MouseUpEvent> _resizeUpHandler;
 
-        private static readonly Color HeaderBackground = new Color(0.18f, 0.18f, 0.18f);
-        private static readonly Color HeaderBorder = new Color(0.25f, 0.25f, 0.25f);
-        private static readonly Color CellBorder = new Color(0.22f, 0.22f, 0.22f);
-        private static readonly Color RowEven = new Color(0.16f, 0.16f, 0.16f);
-        private static readonly Color RowOdd = new Color(0.14f, 0.14f, 0.14f);
+        private static Color HeaderBackground => EditorGUIUtility.isProSkin
+            ? new Color(0.18f, 0.18f, 0.18f) : new Color(0.76f, 0.76f, 0.76f);
+        private static Color HeaderBorder => EditorGUIUtility.isProSkin
+            ? new Color(0.25f, 0.25f, 0.25f) : new Color(0.60f, 0.60f, 0.60f);
+        private static Color CellBorder => EditorGUIUtility.isProSkin
+            ? new Color(0.22f, 0.22f, 0.22f) : new Color(0.70f, 0.70f, 0.70f);
+        private static Color RowEven => EditorGUIUtility.isProSkin
+            ? new Color(0.16f, 0.16f, 0.16f) : new Color(0.83f, 0.83f, 0.83f);
+        private static Color RowOdd => EditorGUIUtility.isProSkin
+            ? new Color(0.14f, 0.14f, 0.14f) : new Color(0.78f, 0.78f, 0.78f);
 
         public void CreateGUI()
         {
@@ -120,29 +123,6 @@ namespace jp.ootr.common.Editor
             return root;
         }
 
-        private static Localization.Language ParseLanguage(string langStr)
-        {
-            switch (langStr)
-            {
-                case "en": return Localization.Language.En;
-                case "fr": return Localization.Language.Fr;
-                case "es": return Localization.Language.Es;
-                case "it": return Localization.Language.It;
-                case "ko": return Localization.Language.Ko;
-                case "de": return Localization.Language.De;
-                case "ja": return Localization.Language.Ja;
-                case "pl": return Localization.Language.Pl;
-                case "ru": return Localization.Language.Ru;
-                case "pt_BR": return Localization.Language.PtBR;
-                case "zh_CN": return Localization.Language.ZhCn;
-                case "zh_HK": return Localization.Language.ZhHk;
-                case "he": return Localization.Language.He;
-                case "tok": return Localization.Language.Tok;
-                case "uk": return Localization.Language.Uk;
-                default: return Localization.Language.En;
-            }
-        }
-
         private void LoadFromTarget()
         {
             _logicalKeys.Clear();
@@ -169,7 +149,7 @@ namespace jp.ootr.common.Editor
                 if (dot < 0) continue;
                 var langStr = fullKey.Substring(0, dot);
                 var logicalKey = fullKey.Substring(dot + 1);
-                var lang = ParseLanguage(langStr);
+                var lang = LanguageUtils.FromStr(langStr);
 
                 if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
                 {
@@ -401,8 +381,7 @@ namespace jp.ootr.common.Editor
             for (var rowIndex = 0; rowIndex < _logicalKeys.Count; rowIndex++)
             {
                 var logicalKey = _logicalKeys[rowIndex];
-                if (!_keyToLangToValue.TryGetValue(logicalKey, out var langToValue))
-                    langToValue = new Dictionary<Localization.Language, string>();
+                var langToValue = _keyToLangToValue[logicalKey];
 
                 var row = new VisualElement { style = { flexDirection = FlexDirection.Row, flexShrink = 0 } };
                 row.style.marginLeft = 0;

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -502,6 +502,7 @@ namespace jp.ootr.common.Editor
             var valuesProp = so.FindProperty("localizationValues");
             if (keysProp == null || valuesProp == null) return;
 
+            Undo.RecordObject(_target, "Edit Localization Data");
             keysProp.arraySize = pairs.Count;
             valuesProp.arraySize = pairs.Count;
             for (var i = 0; i < pairs.Count; i++)
@@ -510,7 +511,6 @@ namespace jp.ootr.common.Editor
                 valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
             }
 
-            Undo.RecordObject(_target, "Edit Localization Data");
             so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
         }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -661,13 +661,20 @@ namespace jp.ootr.common.Editor
                 return;
             }
 
+            foreach (var dict in _keyToLangToValue.Values)
+            {
+                var emptyKeys = dict.Where(kv => string.IsNullOrEmpty(kv.Value))
+                    .Select(kv => kv.Key).ToList();
+                foreach (var k in emptyKeys)
+                    dict.Remove(k);
+            }
+
             _loadedLanguages.Clear();
             foreach (var dict in _keyToLangToValue.Values)
             {
                 foreach (var kv in dict)
                 {
-                    if (!string.IsNullOrEmpty(kv.Value))
-                        _loadedLanguages.Add(kv.Key);
+                    _loadedLanguages.Add(kv.Key);
                 }
             }
 

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -1,0 +1,467 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using jp.ootr.common.Localization;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace jp.ootr.common.Editor
+{
+    public class LocalizationWindow : EditorWindow
+    {
+        [SerializeField] private StyleSheet baseStyleSheet;
+
+        private BaseClass _target;
+        private ObjectField _targetField;
+        private VisualElement _tableContainer;
+        private List<string> _logicalKeys = new List<string>();
+        private Dictionary<string, Dictionary<Localization.Language, string>> _keyToLangToValue =
+            new Dictionary<string, Dictionary<Localization.Language, string>>();
+
+        private static readonly Localization.Language[] AllLanguages =
+            (Localization.Language[])Enum.GetValues(typeof(Localization.Language));
+
+        private const float DefaultKeyColumnWidth = 220f;
+        private const float DefaultLangColumnWidth = 160f;
+        private const float MinColumnWidth = 60f;
+        private const float MaxColumnWidth = 500f;
+        private const float ResizerWidth = 7f;
+        private const float ResizerOffset = (int)ResizerWidth / 2 + 1;
+
+        [SerializeField] private float _keyColumnWidth = DefaultKeyColumnWidth;
+        [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
+
+        private List<List<VisualElement>> _columnCellRefs = new List<List<VisualElement>>();
+        private List<float> _columnWidths = new List<float>();
+        private List<Localization.Language> _visibleLangsSnapshot = new List<Localization.Language>();
+        private int _resizingColumnIndex = -1;
+        private float _resizeStartX;
+        private float _resizeStartWidth;
+        private EventCallback<MouseMoveEvent> _resizeMoveHandler;
+        private EventCallback<MouseUpEvent> _resizeUpHandler;
+
+        private static readonly Color HeaderBackground = new Color(0.18f, 0.18f, 0.18f);
+        private static readonly Color HeaderBorder = new Color(0.25f, 0.25f, 0.25f);
+        private static readonly Color CellBorder = new Color(0.22f, 0.22f, 0.22f);
+        private static readonly Color RowEven = new Color(0.16f, 0.16f, 0.16f);
+        private static readonly Color RowOdd = new Color(0.14f, 0.14f, 0.14f);
+
+        public void CreateGUI()
+        {
+            var root = new VisualElement();
+            if (baseStyleSheet != null)
+            {
+                root.styleSheets.Add(baseStyleSheet);
+                root.AddToClassList("root");
+            }
+
+            root.Add(GetTargetPicker());
+            var toolbar = new VisualElement { style = { flexDirection = FlexDirection.Row, marginBottom = 4 } };
+            var addKeyBtn = new Button(OnAddKey) { text = "Add Key" };
+            var saveBtn = new Button(OnSave) { text = "Save" };
+            toolbar.Add(addKeyBtn);
+            toolbar.Add(saveBtn);
+            root.Add(toolbar);
+
+            _tableContainer = new ScrollView(ScrollViewMode.VerticalAndHorizontal);
+            _tableContainer.style.flexGrow = 1;
+            _tableContainer.style.minHeight = 200;
+            root.Add(_tableContainer);
+
+            if (_target != null)
+                ReloadTable();
+
+            rootVisualElement.Add(root);
+        }
+
+        [MenuItem("Tools/ootr/Localization Window")]
+        public static void ShowWindow()
+        {
+            GetWindow<LocalizationWindow>().titleContent = new GUIContent("Localization");
+        }
+
+        public static void ShowWindowWithTarget(BaseClass target)
+        {
+            var wnd = GetWindow<LocalizationWindow>();
+            wnd.titleContent = new GUIContent("Localization");
+            wnd._target = target;
+            if (wnd._targetField != null)
+                wnd._targetField.value = target;
+            if (wnd._tableContainer != null)
+                wnd.ReloadTable();
+        }
+
+        private VisualElement GetTargetPicker()
+        {
+            var root = new VisualElement();
+            _targetField = new ObjectField
+            {
+                label = "Target",
+                objectType = typeof(BaseClass),
+                value = _target
+            };
+            _targetField.RegisterValueChangedCallback(evt =>
+            {
+                _target = (BaseClass)evt.newValue;
+                ReloadTable();
+            });
+            root.Add(_targetField);
+            return root;
+        }
+
+        private static Localization.Language ParseLanguage(string langStr)
+        {
+            switch (langStr)
+            {
+                case "en": return Localization.Language.En;
+                case "fr": return Localization.Language.Fr;
+                case "es": return Localization.Language.Es;
+                case "it": return Localization.Language.It;
+                case "ko": return Localization.Language.Ko;
+                case "de": return Localization.Language.De;
+                case "ja": return Localization.Language.Ja;
+                case "pl": return Localization.Language.Pl;
+                case "ru": return Localization.Language.Ru;
+                case "pt_BR": return Localization.Language.PtBR;
+                case "zh_CN": return Localization.Language.ZhCn;
+                case "zh_HK": return Localization.Language.ZhHk;
+                case "he": return Localization.Language.He;
+                case "tok": return Localization.Language.Tok;
+                case "uk": return Localization.Language.Uk;
+                default: return Localization.Language.En;
+            }
+        }
+
+        private void LoadFromTarget()
+        {
+            _logicalKeys.Clear();
+            _keyToLangToValue.Clear();
+            if (_target == null) return;
+
+            var so = new SerializedObject(_target);
+            var keysProp = so.FindProperty("localizationKeys");
+            var valuesProp = so.FindProperty("localizationValues");
+            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+                return;
+
+            var keyOrder = new List<string>();
+            var seen = new HashSet<string>();
+
+            for (var i = 0; i < keysProp.arraySize; i++)
+            {
+                var fullKey = keysProp.GetArrayElementAtIndex(i).stringValue;
+                var value = valuesProp.GetArrayElementAtIndex(i).stringValue ?? "";
+                if (string.IsNullOrEmpty(fullKey)) continue;
+
+                var dot = fullKey.IndexOf('.');
+                if (dot < 0) continue;
+                var langStr = fullKey.Substring(0, dot);
+                var logicalKey = fullKey.Substring(dot + 1);
+                var lang = ParseLanguage(langStr);
+
+                if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
+                {
+                    _keyToLangToValue[logicalKey] = dict = new Dictionary<Localization.Language, string>();
+                    if (!seen.Contains(logicalKey))
+                    {
+                        seen.Add(logicalKey);
+                        keyOrder.Add(logicalKey);
+                    }
+                }
+
+                dict[lang] = value;
+            }
+
+            _logicalKeys = keyOrder;
+        }
+
+        /// <summary>
+        /// Returns languages that have at least one non-empty value in the current data.
+        /// Order follows AllLanguages (enum order).
+        /// </summary>
+        private List<Localization.Language> GetVisibleLanguages()
+        {
+            var hasValue = new HashSet<Localization.Language>();
+            foreach (var dict in _keyToLangToValue.Values)
+            {
+                foreach (var kv in dict)
+                {
+                    if (!string.IsNullOrEmpty(kv.Value))
+                        hasValue.Add(kv.Key);
+                }
+            }
+            // いずれのキーにも値がない場合は全言語を表示（新規入力用）
+            if (hasValue.Count == 0 && _logicalKeys.Count > 0)
+                return new List<Localization.Language>(AllLanguages);
+            return AllLanguages.Where(hasValue.Contains).ToList();
+        }
+
+        private float GetLangColumnWidth(Localization.Language lang)
+        {
+            var idx = (int)lang;
+            while (_langColumnWidths.Count <= idx)
+                _langColumnWidths.Add(DefaultLangColumnWidth);
+            return Mathf.Clamp(_langColumnWidths[idx], MinColumnWidth, MaxColumnWidth);
+        }
+
+        private void SetLangColumnWidth(Localization.Language lang, float width)
+        {
+            var idx = (int)lang;
+            while (_langColumnWidths.Count <= idx)
+                _langColumnWidths.Add(DefaultLangColumnWidth);
+            _langColumnWidths[idx] = Mathf.Clamp(width, MinColumnWidth, MaxColumnWidth);
+        }
+
+        private static void SetCellStyle(VisualElement cell, float width)
+        {
+            cell.style.width = width;
+            cell.style.minWidth = width;
+            cell.style.maxWidth = width;
+            cell.style.flexShrink = 0;
+            cell.style.flexGrow = 0;
+            cell.style.borderRightWidth = 1;
+            cell.style.borderRightColor = new StyleColor(CellBorder);
+            cell.style.marginLeft = 0;
+            cell.style.marginRight = 0;
+            cell.style.marginTop = 0;
+            cell.style.marginBottom = 0;
+            cell.style.paddingLeft = 4;
+            cell.style.paddingRight = 4;
+        }
+
+        private VisualElement CreateResizer(int columnIndex)
+        {
+            var resizer = new VisualElement();
+            resizer.style.width = ResizerWidth;
+            resizer.style.minWidth = ResizerWidth;
+            resizer.style.right = -ResizerOffset;
+            resizer.style.flexShrink = 0;
+            resizer.style.backgroundColor = new StyleColor(HeaderBorder);
+
+            resizer.RegisterCallback<MouseDownEvent>(evt =>
+            {
+                if (evt.button != 0) return;
+                _resizingColumnIndex = columnIndex;
+                _resizeStartX = evt.mousePosition.x;
+                _resizeStartWidth = _columnWidths[columnIndex];
+                resizer.CaptureMouse();
+                evt.StopPropagation();
+            });
+
+            resizer.RegisterCallback<MouseMoveEvent>(evt =>
+            {
+                if (_resizingColumnIndex != columnIndex) return;
+                var delta = evt.mousePosition.x - _resizeStartX;
+                var newWidth = Mathf.Clamp(_resizeStartWidth + delta, MinColumnWidth, MaxColumnWidth);
+                ApplyColumnWidth(columnIndex, newWidth);
+                evt.StopPropagation();
+            });
+
+            resizer.RegisterCallback<MouseUpEvent>(evt =>
+            {
+                if (evt.button != 0) return;
+                if (_resizingColumnIndex == columnIndex)
+                {
+                    resizer.ReleaseMouse();
+                    _resizingColumnIndex = -1;
+                }
+                evt.StopPropagation();
+            });
+
+            return resizer;
+        }
+
+        private VisualElement CreateHeaderCell(string title, int columnIndex)
+        {
+            var container = new VisualElement();
+            container.style.position = Position.Relative;
+            SetCellStyle(container, _columnWidths[columnIndex]);
+
+            var label = new Label(title);
+            label.AddToClassList("unity-font-element-bold");
+            label.style.unityTextAlign = TextAnchor.MiddleLeft;
+            container.Add(label);
+
+            var resizer = CreateResizer(columnIndex);
+            resizer.style.position = Position.Absolute;
+            resizer.style.top = 0;
+            resizer.style.bottom = 0;
+            container.Add(resizer);
+
+            _columnCellRefs[columnIndex].Add(container);
+            return container;
+        }
+
+        private void ApplyColumnWidth(int columnIndex, float width)
+        {
+            _columnWidths[columnIndex] = width;
+            if (columnIndex == 0)
+                _keyColumnWidth = width;
+            else if (columnIndex <= _visibleLangsSnapshot.Count)
+                SetLangColumnWidth(_visibleLangsSnapshot[columnIndex - 1], width);
+
+            if (columnIndex >= _columnCellRefs.Count) return;
+            var cells = _columnCellRefs[columnIndex];
+            if (cells == null) return;
+            foreach (var c in cells)
+            {
+                c.style.width = width;
+                c.style.minWidth = width;
+                c.style.maxWidth = width;
+            }
+        }
+
+        /// <param name="loadFromTarget">true のとき SerializedObject から再読み込み。Add Key 時は false でメモリ上のデータのみでテーブル再描画。</param>
+        private void ReloadTable(bool loadFromTarget = true)
+        {
+            if (loadFromTarget)
+                LoadFromTarget();
+            _tableContainer.Clear();
+            _columnCellRefs.Clear();
+            _columnWidths.Clear();
+            _visibleLangsSnapshot = GetVisibleLanguages();
+
+            _keyColumnWidth = Mathf.Clamp(_keyColumnWidth, MinColumnWidth, MaxColumnWidth);
+            _columnWidths.Add(_keyColumnWidth);
+            for (var i = 0; i < _visibleLangsSnapshot.Count; i++)
+                _columnWidths.Add(GetLangColumnWidth(_visibleLangsSnapshot[i]));
+
+            var table = new VisualElement();
+            table.style.flexDirection = FlexDirection.Column;
+            table.style.flexShrink = 0;
+            var totalWidth = _columnWidths.Sum();
+            table.style.minWidth = totalWidth;
+
+            var keyColumnCells = new List<VisualElement>();
+            _columnCellRefs.Add(keyColumnCells);
+            for (var i = 0; i < _visibleLangsSnapshot.Count; i++)
+                _columnCellRefs.Add(new List<VisualElement>());
+
+            // Header row
+            var headerRow = new VisualElement { style = { flexDirection = FlexDirection.Row, flexShrink = 0 } };
+            headerRow.style.marginLeft = 0;
+            headerRow.style.marginRight = 0;
+            headerRow.style.marginTop = 0;
+            headerRow.style.marginBottom = 0;
+            headerRow.style.backgroundColor = new StyleColor(HeaderBackground);
+            headerRow.style.borderBottomWidth = 1;
+            headerRow.style.borderBottomColor = new StyleColor(HeaderBorder);
+
+            var keyHeaderCell = CreateHeaderCell("Key", 0);
+            keyColumnCells.Add(keyHeaderCell);
+            headerRow.Add(keyHeaderCell);
+
+            for (var c = 0; c < _visibleLangsSnapshot.Count; c++)
+            {
+                var headerCell = CreateHeaderCell(_visibleLangsSnapshot[c].ToString(), c + 1);
+                headerRow.Add(headerCell);
+            }
+            table.Add(headerRow);
+
+            for (var rowIndex = 0; rowIndex < _logicalKeys.Count; rowIndex++)
+            {
+                var logicalKey = _logicalKeys[rowIndex];
+                if (!_keyToLangToValue.TryGetValue(logicalKey, out var langToValue))
+                    langToValue = new Dictionary<Localization.Language, string>();
+
+                var row = new VisualElement { style = { flexDirection = FlexDirection.Row, flexShrink = 0 } };
+                row.style.marginLeft = 0;
+                row.style.marginRight = 0;
+                row.style.marginTop = 0;
+                row.style.marginBottom = 0;
+                row.style.backgroundColor = new StyleColor(rowIndex % 2 == 0 ? RowEven : RowOdd);
+
+                var keyField = new TextField { value = logicalKey };
+                SetCellStyle(keyField, _columnWidths[0]);
+                keyColumnCells.Add(keyField);
+                var idx = rowIndex;
+                keyField.RegisterValueChangedCallback(evt =>
+                {
+                    var newKey = evt.newValue?.Trim() ?? "";
+                    if (string.IsNullOrEmpty(newKey) || newKey == _logicalKeys[idx]) return;
+                    var oldKey = _logicalKeys[idx];
+                    if (_keyToLangToValue.ContainsKey(newKey)) return;
+                    _keyToLangToValue[newKey] = _keyToLangToValue[oldKey];
+                    _keyToLangToValue.Remove(oldKey);
+                    _logicalKeys[idx] = newKey;
+                });
+                row.Add(keyField);
+
+                for (var c = 0; c < _visibleLangsSnapshot.Count; c++)
+                {
+                    var lang1 = _visibleLangsSnapshot[c];
+                    var current = langToValue.TryGetValue(lang1, out var v) ? v : "";
+                    var tf = new TextField { value = current };
+                    SetCellStyle(tf, _columnWidths[c + 1]);
+                    _columnCellRefs[c + 1].Add(tf);
+                    tf.RegisterValueChangedCallback(evt =>
+                    {
+                        var key = _logicalKeys[idx];
+                        if (!_keyToLangToValue.TryGetValue(key, out var d))
+                        {
+                            d = new Dictionary<Localization.Language, string>();
+                            _keyToLangToValue[key] = d;
+                        }
+                        d[lang1] = evt.newValue;
+                    });
+                    row.Add(tf);
+                }
+
+                table.Add(row);
+            }
+
+            _tableContainer.Add(table);
+        }
+
+        private void OnAddKey()
+        {
+            if (_target == null) return;
+            var baseName = "new_key";
+            var name = baseName;
+            var c = 0;
+            while (_keyToLangToValue.ContainsKey(name))
+                name = $"{baseName}_{++c}";
+            _logicalKeys.Add(name);
+            _keyToLangToValue[name] = new Dictionary<Localization.Language, string>();
+            ReloadTable(loadFromTarget: false);
+        }
+
+        private void OnSave()
+        {
+            if (_target == null) return;
+
+            var visibleLangs = GetVisibleLanguages();
+            var pairs = new List<(string fullKey, string value)>();
+            foreach (var key in _logicalKeys)
+            {
+                if (!_keyToLangToValue.TryGetValue(key, out var dict))
+                    dict = new Dictionary<Localization.Language, string>();
+                foreach (var lang in visibleLangs)
+                {
+                    var value = dict.TryGetValue(lang, out var v) ? v : "";
+                    var fullKey = $"{LanguageUtils.ToStr(lang)}.{key}";
+                    pairs.Add((fullKey, value));
+                }
+            }
+
+            var so = new SerializedObject(_target);
+            var keysProp = so.FindProperty("localizationKeys");
+            var valuesProp = so.FindProperty("localizationValues");
+            if (keysProp == null || valuesProp == null) return;
+
+            keysProp.arraySize = pairs.Count;
+            valuesProp.arraySize = pairs.Count;
+            for (var i = 0; i < pairs.Count; i++)
+            {
+                keysProp.GetArrayElementAtIndex(i).stringValue = pairs[i].fullKey;
+                valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
+            }
+
+            so.ApplyModifiedPropertiesWithoutUndo();
+        }
+    }
+}
+#endif

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -14,7 +14,7 @@ namespace jp.ootr.common.Editor
     {
         [SerializeField] private StyleSheet baseStyleSheet;
 
-        private BaseClass _target;
+        [SerializeField] private BaseClass _target;
         private ObjectField _targetField;
         private VisualElement _tableContainer;
         private List<string> _logicalKeys = new List<string>();
@@ -139,13 +139,13 @@ namespace jp.ootr.common.Editor
             var keysProp = so.FindProperty("localizationKeys");
             var valuesProp = so.FindProperty("localizationValues");
 
+            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
+                return;
+
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
             _explicitlyAddedLanguages.Clear();
             _loadedLanguages.Clear();
-
-            if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
-                return;
 
             var keyOrder = new List<string>();
             var seen = new HashSet<string>();
@@ -300,6 +300,15 @@ namespace jp.ootr.common.Editor
                 evt.StopPropagation();
             });
 
+            resizer.RegisterCallback<DetachFromPanelEvent>(_ =>
+            {
+                if (_resizingColumnIndex == columnIndex)
+                {
+                    resizer.ReleaseMouse();
+                    _resizingColumnIndex = -1;
+                }
+            });
+
             return resizer;
         }
 
@@ -401,10 +410,21 @@ namespace jp.ootr.common.Editor
                 row.style.marginBottom = 0;
                 row.style.backgroundColor = new StyleColor(rowIndex % 2 == 0 ? RowEven : RowOdd);
 
+                var idx = rowIndex;
+                var deleteBtn = new Button(() =>
+                {
+                    _logicalKeys.RemoveAt(idx);
+                    _keyToLangToValue.Remove(logicalKey);
+                    ReloadTable(loadFromTarget: false);
+                }) { text = "✕" };
+                deleteBtn.style.width = 20;
+                deleteBtn.style.minWidth = 20;
+                deleteBtn.style.flexShrink = 0;
+                row.Add(deleteBtn);
+
                 var keyField = new TextField { value = logicalKey };
                 SetCellStyle(keyField, _columnWidths[0]);
                 keyColumnCells.Add(keyField);
-                var idx = rowIndex;
                 keyField.RegisterValueChangedCallback(evt =>
                 {
                     var newKey = evt.newValue?.Trim() ?? "";
@@ -462,7 +482,8 @@ namespace jp.ootr.common.Editor
             if (_target == null) return;
 
             var saveLangs = AllLanguages
-                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l))
+                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l)
+                    || _keyToLangToValue.Values.Any(d => d.ContainsKey(l)))
                 .ToList();
             var pairs = new List<(string fullKey, string value)>();
             foreach (var key in _logicalKeys)

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -584,8 +584,7 @@ namespace jp.ootr.common.Editor
             }
 
             var saveLangs = AllLanguages
-                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l)
-                    || _keyToLangToValue.Values.Any(d => d.TryGetValue(l, out var v) && !string.IsNullOrEmpty(v)))
+                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l))
                 .ToList();
             var pairs = new List<(string fullKey, string value)>();
             foreach (var key in _logicalKeys)
@@ -622,7 +621,7 @@ namespace jp.ootr.common.Editor
 
             so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
-            AssetDatabase.SaveAssets();
+            AssetDatabase.SaveAssetIfDirty(_target);
             _isDirty = false;
         }
     }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -103,7 +103,7 @@ namespace jp.ootr.common.Editor
             var wnd = GetWindow<LocalizationWindow>();
             wnd.titleContent = new GUIContent("Localization");
 
-            if (wnd._isDirty && !EditorUtility.DisplayDialog(
+            if (wnd._isDirty && wnd._target != target && !EditorUtility.DisplayDialog(
                     "Unsaved Changes",
                     "You have unsaved localization changes. Discard them?",
                     "Discard", "Cancel"))
@@ -204,7 +204,8 @@ namespace jp.ootr.common.Editor
                 var logicalKey = fullKey.Substring(dot + 1);
                 var lang = FromStr(langStr);
                 if (lang == null) continue;
-                _loadedLanguages.Add(lang.Value);
+                if (!string.IsNullOrEmpty(value))
+                    _loadedLanguages.Add(lang.Value);
 
                 if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
                 {
@@ -575,8 +576,11 @@ namespace jp.ootr.common.Editor
             _loadedLanguages.Clear();
             foreach (var dict in _keyToLangToValue.Values)
             {
-                foreach (var lang in dict.Keys)
-                    _loadedLanguages.Add(lang);
+                foreach (var kv in dict)
+                {
+                    if (!string.IsNullOrEmpty(kv.Value))
+                        _loadedLanguages.Add(kv.Key);
+                }
             }
 
             var saveLangs = AllLanguages

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -39,6 +39,7 @@ namespace jp.ootr.common.Editor
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
         private bool _malformedDataOnLoad;
         private bool _isDirty;
+        private int _tableGeneration;
 
         private DropdownField _langDropdown;
 
@@ -354,7 +355,7 @@ namespace jp.ootr.common.Editor
                 if (evt.button != 0) return;
                 _resizingColumnIndex = columnIndex;
                 _resizeStartX = evt.mousePosition.x;
-                _resizeStartWidth = _columnWidths[columnIndex];
+                _resizeStartWidth = columnIndex < _columnWidths.Count ? _columnWidths[columnIndex] : 0f;
                 resizer.CaptureMouse();
                 evt.StopPropagation();
             });
@@ -414,6 +415,7 @@ namespace jp.ootr.common.Editor
 
         private void ApplyColumnWidth(int columnIndex, float width)
         {
+            if (columnIndex >= _columnWidths.Count) return;
             _columnWidths[columnIndex] = width;
             if (columnIndex == 0)
                 _keyColumnWidth = width;
@@ -437,6 +439,7 @@ namespace jp.ootr.common.Editor
         /// <param name="loadFromTarget">true のとき SerializedObject から再読み込み。Add Key 時は false でメモリ上のデータのみでテーブル再描画。</param>
         private void ReloadTable(bool loadFromTarget = true)
         {
+            _tableGeneration++;
             if (loadFromTarget)
                 LoadFromTarget();
             if (_malformedDataOnLoad)
@@ -493,6 +496,7 @@ namespace jp.ootr.common.Editor
             }
             _table.Add(headerRow);
 
+            var gen = _tableGeneration;
             for (var rowIndex = 0; rowIndex < _logicalKeys.Count; rowIndex++)
             {
                 var logicalKey = _logicalKeys[rowIndex];
@@ -508,6 +512,7 @@ namespace jp.ootr.common.Editor
                 var idx = rowIndex;
                 var deleteBtn = new Button(() =>
                 {
+                    if (gen != _tableGeneration) return;
                     if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                     if (!EditorUtility.DisplayDialog("Delete Key",
                             $"Delete localization key '{logicalKey}' and all its translations?",
@@ -534,6 +539,7 @@ namespace jp.ootr.common.Editor
                 keyColumnCells.Add(keyField);
                 void ApplyOrRevertKeyRename()
                 {
+                    if (gen != _tableGeneration) return;
                     if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                     var oldKey = _logicalKeys[idx];
                     var newKey = keyField.value?.Trim() ?? "";
@@ -578,6 +584,7 @@ namespace jp.ootr.common.Editor
                     _columnCellRefs[c + 1].Add(tf);
                     tf.RegisterValueChangedCallback(evt =>
                     {
+                        if (gen != _tableGeneration) return;
                         if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                         var key = _logicalKeys[idx];
                         if (!_keyToLangToValue.TryGetValue(key, out var d))
@@ -652,7 +659,6 @@ namespace jp.ootr.common.Editor
                 foreach (var lang in saveLangs)
                 {
                     var value = dict.TryGetValue(lang, out var v) ? v : "";
-                    if (string.IsNullOrEmpty(value) && !_loadedLanguages.Contains(lang)) continue;
                     var langPrefix = LanguageUtils.ToStr(lang);
                     if (langPrefix == "en" && lang != Localization.Language.En)
                     {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -109,7 +109,14 @@ namespace jp.ootr.common.Editor
             var wnd = GetWindow<LocalizationWindow>();
             wnd.titleContent = new GUIContent("Localization");
 
-            if (wnd._isDirty && wnd._target != target && !EditorUtility.DisplayDialog(
+            if (wnd._target == target)
+            {
+                wnd.Show();
+                wnd.Focus();
+                return;
+            }
+
+            if (wnd._isDirty && !EditorUtility.DisplayDialog(
                     "Unsaved Changes",
                     "You have unsaved localization changes. Discard them?",
                     "Discard", "Cancel"))
@@ -514,8 +521,14 @@ namespace jp.ootr.common.Editor
                     if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
                     var oldKey = _logicalKeys[idx];
                     var newKey = keyField.value?.Trim() ?? "";
-                    if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey || _keyToLangToValue.ContainsKey(newKey))
+                    if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey)
                     {
+                        keyField.SetValueWithoutNotify(oldKey);
+                        return;
+                    }
+                    if (_keyToLangToValue.ContainsKey(newKey))
+                    {
+                        Debug.LogWarning($"[Localization] Cannot rename '{oldKey}' to '{newKey}': a key with that name already exists.");
                         keyField.SetValueWithoutNotify(oldKey);
                         return;
                     }
@@ -633,7 +646,6 @@ namespace jp.ootr.common.Editor
             var valuesProp = so.FindProperty("localizationValues");
             if (keysProp == null || valuesProp == null) return;
 
-            Undo.RecordObject(_target, "Edit Localization Data");
             keysProp.arraySize = pairs.Count;
             valuesProp.arraySize = pairs.Count;
             for (var i = 0; i < pairs.Count; i++)
@@ -642,7 +654,7 @@ namespace jp.ootr.common.Editor
                 valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
             }
 
-            so.ApplyModifiedPropertiesWithoutUndo();
+            so.ApplyModifiedProperties();
             EditorUtility.SetDirty(_target);
             if (!EditorUtility.IsPersistent(_target))
             {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -33,6 +33,9 @@ namespace jp.ootr.common.Editor
 
         [SerializeField] private float _keyColumnWidth = DefaultKeyColumnWidth;
         [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
+        [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
+
+        private DropdownField _langDropdown;
 
         private List<List<VisualElement>> _columnCellRefs = new List<List<VisualElement>>();
         private List<float> _columnWidths = new List<float>();
@@ -62,8 +65,13 @@ namespace jp.ootr.common.Editor
             var toolbar = new VisualElement { style = { flexDirection = FlexDirection.Row, marginBottom = 4 } };
             var addKeyBtn = new Button(OnAddKey) { text = "Add Key" };
             var saveBtn = new Button(OnSave) { text = "Save" };
+            _langDropdown = new DropdownField { style = { minWidth = 120 } };
+            UpdateLangDropdownChoices();
+            var addLangBtn = new Button(OnAddLanguage) { text = "Add" };
             toolbar.Add(addKeyBtn);
             toolbar.Add(saveBtn);
+            toolbar.Add(_langDropdown);
+            toolbar.Add(addLangBtn);
             root.Add(toolbar);
 
             _tableContainer = new ScrollView(ScrollViewMode.VerticalAndHorizontal);
@@ -139,6 +147,7 @@ namespace jp.ootr.common.Editor
         {
             _logicalKeys.Clear();
             _keyToLangToValue.Clear();
+            _explicitlyAddedLanguages.Clear();
             if (_target == null) return;
 
             var so = new SerializedObject(_target);
@@ -193,10 +202,38 @@ namespace jp.ootr.common.Editor
                         hasValue.Add(kv.Key);
                 }
             }
+
+            // 明示的に追加された言語も含める
+            foreach (var lang in _explicitlyAddedLanguages)
+                hasValue.Add(lang);
+
             // いずれのキーにも値がない場合は全言語を表示（新規入力用）
             if (hasValue.Count == 0 && _logicalKeys.Count > 0)
                 return new List<Localization.Language>(AllLanguages);
             return AllLanguages.Where(hasValue.Contains).ToList();
+        }
+
+        private void UpdateLangDropdownChoices()
+        {
+            if (_langDropdown == null) return;
+            var current = new HashSet<Localization.Language>(GetVisibleLanguages());
+            var choices = AllLanguages
+                .Where(l => !current.Contains(l))
+                .Select(l => l.ToString())
+                .ToList();
+            _langDropdown.choices = choices;
+            _langDropdown.value = choices.Count > 0 ? choices[0] : "";
+        }
+
+        private void OnAddLanguage()
+        {
+            if (_target == null || _langDropdown == null) return;
+            if (string.IsNullOrEmpty(_langDropdown.value)) return;
+            if (!Enum.TryParse<Localization.Language>(_langDropdown.value, out var lang)) return;
+            if (!_explicitlyAddedLanguages.Contains(lang))
+                _explicitlyAddedLanguages.Add(lang);
+            ReloadTable(loadFromTarget: false);
+            UpdateLangDropdownChoices();
         }
 
         private float GetLangColumnWidth(Localization.Language lang)
@@ -414,6 +451,7 @@ namespace jp.ootr.common.Editor
             }
 
             _tableContainer.Add(table);
+            UpdateLangDropdownChoices();
         }
 
         private void OnAddKey()

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -59,11 +59,6 @@ namespace jp.ootr.common.Editor
         private static Color RowOdd => EditorGUIUtility.isProSkin
             ? new Color(0.14f, 0.14f, 0.14f) : new Color(0.78f, 0.78f, 0.78f);
 
-        public override bool hasUnsavedChanges => _isDirty;
-
-        public override string saveChangesMessage =>
-            "You have unsaved localization changes. Save before closing?";
-
         public override void SaveChanges()
         {
             OnSave();
@@ -122,6 +117,7 @@ namespace jp.ootr.common.Editor
 
             wnd._target = target;
             wnd._isDirty = false;
+            wnd.hasUnsavedChanges = false;
             if (wnd._targetField != null)
                 wnd._targetField.SetValueWithoutNotify(target);
             if (wnd._tableContainer != null)
@@ -158,6 +154,7 @@ namespace jp.ootr.common.Editor
                     return;
                 }
                 _isDirty = false;
+                hasUnsavedChanges = false;
                 _target = (BaseClass)evt.newValue;
                 ReloadTable();
             });
@@ -190,6 +187,7 @@ namespace jp.ootr.common.Editor
                 _loadedLanguages.Clear();
                 _explicitlyAddedLanguages.Clear();
                 _isDirty = false;
+                hasUnsavedChanges = false;
                 return;
             }
 
@@ -234,6 +232,7 @@ namespace jp.ootr.common.Editor
             _logicalKeys = keyOrder;
             _lastLoadedTarget = _target;
             _isDirty = false;
+            hasUnsavedChanges = false;
         }
 
         /// <summary>
@@ -287,6 +286,8 @@ namespace jp.ootr.common.Editor
             if (!_explicitlyAddedLanguages.Contains(lang.Value))
                 _explicitlyAddedLanguages.Add(lang.Value);
             _isDirty = true;
+            hasUnsavedChanges = true;
+            saveChangesMessage = "You have unsaved localization changes. Save before closing?";
             ReloadTable(loadFromTarget: false);
         }
 
@@ -491,6 +492,8 @@ namespace jp.ootr.common.Editor
                     _logicalKeys.RemoveAt(idx);
                     _keyToLangToValue.Remove(liveKey);
                     _isDirty = true;
+                    hasUnsavedChanges = true;
+                    saveChangesMessage = "You have unsaved localization changes. Save before closing?";
                     ReloadTable(loadFromTarget: false);
                 }) { text = "✕" };
                 deleteBtn.style.width = 20;
@@ -520,6 +523,8 @@ namespace jp.ootr.common.Editor
                     _logicalKeys[idx] = newKey;
                     keyField.SetValueWithoutNotify(newKey);
                     _isDirty = true;
+                    hasUnsavedChanges = true;
+                    saveChangesMessage = "You have unsaved localization changes. Save before closing?";
                 }
                 keyField.RegisterCallback<FocusOutEvent>(evt => ApplyOrRevertKeyRename());
                 keyField.RegisterCallback<KeyDownEvent>(evt =>
@@ -549,6 +554,8 @@ namespace jp.ootr.common.Editor
                         }
                         d[lang1] = evt.newValue;
                         _isDirty = true;
+                        hasUnsavedChanges = true;
+                        saveChangesMessage = "You have unsaved localization changes. Save before closing?";
                     });
                     row.Add(tf);
                 }
@@ -572,6 +579,8 @@ namespace jp.ootr.common.Editor
             _logicalKeys.Add(name);
             _keyToLangToValue[name] = new Dictionary<Localization.Language, string>();
             _isDirty = true;
+            hasUnsavedChanges = true;
+            saveChangesMessage = "You have unsaved localization changes. Save before closing?";
             ReloadTable(loadFromTarget: false);
         }
 
@@ -641,6 +650,7 @@ namespace jp.ootr.common.Editor
                 AssetDatabase.SaveAssetIfDirty(_target);
             }
             _isDirty = false;
+            hasUnsavedChanges = false;
         }
     }
 }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -256,7 +256,7 @@ namespace jp.ootr.common.Editor
             var current = new HashSet<Localization.Language>(GetVisibleLanguages());
             var choices = AllLanguages
                 .Where(l => !current.Contains(l))
-                .Select(l => l.ToString())
+                .Select(l => LanguageUtils.ToStr(l))
                 .ToList();
             _langDropdown.choices = choices;
             _langDropdown.value = choices.Count > 0 ? choices[0] : "";
@@ -267,9 +267,10 @@ namespace jp.ootr.common.Editor
             if (_target == null || _langDropdown == null) return;
             if (_malformedDataOnLoad) return;
             if (string.IsNullOrEmpty(_langDropdown.value)) return;
-            if (!Enum.TryParse<Localization.Language>(_langDropdown.value, out var lang)) return;
-            if (!_explicitlyAddedLanguages.Contains(lang))
-                _explicitlyAddedLanguages.Add(lang);
+            var lang = FromStr(_langDropdown.value);
+            if (lang == null) return;
+            if (!_explicitlyAddedLanguages.Contains(lang.Value))
+                _explicitlyAddedLanguages.Add(lang.Value);
             _isDirty = true;
             ReloadTable(loadFromTarget: false);
         }
@@ -568,24 +569,11 @@ namespace jp.ootr.common.Editor
                 return;
             }
 
-            if (_loadedLanguages.Count == 0)
+            _loadedLanguages.Clear();
+            foreach (var dict in _keyToLangToValue.Values)
             {
-                var soPre = new SerializedObject(_target);
-                var keysPropPre = soPre.FindProperty("localizationKeys");
-                if (keysPropPre != null)
-                {
-                    for (var i = 0; i < keysPropPre.arraySize; i++)
-                    {
-                        var fullKey = keysPropPre.GetArrayElementAtIndex(i).stringValue;
-                        if (string.IsNullOrEmpty(fullKey)) continue;
-                        var dot = fullKey.IndexOf('.');
-                        if (dot < 0) continue;
-                        var langStr = fullKey.Substring(0, dot);
-                        var lang = FromStr(langStr);
-                        if (lang != null)
-                            _loadedLanguages.Add(lang.Value);
-                    }
-                }
+                foreach (var lang in dict.Keys)
+                    _loadedLanguages.Add(lang);
             }
 
             var saveLangs = AllLanguages
@@ -627,6 +615,7 @@ namespace jp.ootr.common.Editor
 
             so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
+            AssetDatabase.SaveAssets();
             _isDirty = false;
         }
     }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -29,7 +29,7 @@ namespace jp.ootr.common.Editor
         private const float MinColumnWidth = 60f;
         private const float MaxColumnWidth = 500f;
         private const float ResizerWidth = 7f;
-        private const float ResizerOffset = (int)ResizerWidth / 2 + 1;
+        private const float ResizerOffset = ResizerWidth / 2f + 1f;
 
         [SerializeField] private float _keyColumnWidth = DefaultKeyColumnWidth;
         [SerializeField] private List<float> _langColumnWidths = new List<float>(); // index = (int)Language
@@ -125,16 +125,23 @@ namespace jp.ootr.common.Editor
 
         private void LoadFromTarget()
         {
-            _logicalKeys.Clear();
-            _keyToLangToValue.Clear();
-            _explicitlyAddedLanguages.Clear();
-            if (_target == null) return;
+            if (_target == null)
+            {
+                _logicalKeys.Clear();
+                _keyToLangToValue.Clear();
+                _explicitlyAddedLanguages.Clear();
+                return;
+            }
 
             var so = new SerializedObject(_target);
             var keysProp = so.FindProperty("localizationKeys");
             var valuesProp = so.FindProperty("localizationValues");
             if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
                 return;
+
+            _logicalKeys.Clear();
+            _keyToLangToValue.Clear();
+            _explicitlyAddedLanguages.Clear();
 
             var keyOrder = new List<string>();
             var seen = new HashSet<string>();
@@ -150,6 +157,7 @@ namespace jp.ootr.common.Editor
                 var langStr = fullKey.Substring(0, dot);
                 var logicalKey = fullKey.Substring(dot + 1);
                 var lang = LanguageUtils.FromStr(langStr);
+                if (lang == null) continue;
 
                 if (!_keyToLangToValue.TryGetValue(logicalKey, out var dict))
                 {
@@ -161,7 +169,7 @@ namespace jp.ootr.common.Editor
                     }
                 }
 
-                dict[lang] = value;
+                dict[lang.Value] = value;
             }
 
             _logicalKeys = keyOrder;
@@ -368,7 +376,6 @@ namespace jp.ootr.common.Editor
             headerRow.style.borderBottomColor = new StyleColor(HeaderBorder);
 
             var keyHeaderCell = CreateHeaderCell("Key", 0);
-            keyColumnCells.Add(keyHeaderCell);
             headerRow.Add(keyHeaderCell);
 
             for (var c = 0; c < _visibleLangsSnapshot.Count; c++)
@@ -477,7 +484,9 @@ namespace jp.ootr.common.Editor
                 valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
             }
 
-            so.ApplyModifiedPropertiesWithoutUndo();
+            Undo.RecordObject(_target, "Edit Localization Data");
+            so.ApplyModifiedProperties();
+            EditorUtility.SetDirty(_target);
         }
     }
 }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -17,6 +17,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private BaseClass _target;
         private ObjectField _targetField;
         private VisualElement _tableContainer;
+        private VisualElement _table;
         private List<string> _logicalKeys = new List<string>();
         private Dictionary<string, Dictionary<Localization.Language, string>> _keyToLangToValue =
             new Dictionary<string, Dictionary<Localization.Language, string>>();
@@ -429,8 +430,8 @@ namespace jp.ootr.common.Editor
                 c.style.maxWidth = width;
             }
 
-            if (_tableContainer?.contentContainer?.Children().FirstOrDefault() is VisualElement table)
-                table.style.minWidth = _columnWidths.Sum() + 20f;
+            if (_table != null)
+                _table.style.minWidth = _columnWidths.Sum() + 20f;
         }
 
         /// <param name="loadFromTarget">true のとき SerializedObject から再読み込み。Add Key 時は false でメモリ上のデータのみでテーブル再描画。</param>
@@ -441,6 +442,7 @@ namespace jp.ootr.common.Editor
             if (_malformedDataOnLoad)
             {
                 _tableContainer.Clear();
+                _table = null;
                 _tableContainer.Add(new Label("Localization data could not be loaded (malformed or mismatched arrays)."));
                 return;
             }
@@ -454,11 +456,11 @@ namespace jp.ootr.common.Editor
             for (var i = 0; i < _visibleLangsSnapshot.Count; i++)
                 _columnWidths.Add(GetLangColumnWidth(_visibleLangsSnapshot[i]));
 
-            var table = new VisualElement();
-            table.style.flexDirection = FlexDirection.Column;
-            table.style.flexShrink = 0;
+            _table = new VisualElement();
+            _table.style.flexDirection = FlexDirection.Column;
+            _table.style.flexShrink = 0;
             var totalWidth = _columnWidths.Sum();
-            table.style.minWidth = totalWidth + 20f;
+            _table.style.minWidth = totalWidth + 20f;
 
             var keyColumnCells = new List<VisualElement>();
             _columnCellRefs.Add(keyColumnCells);
@@ -489,7 +491,7 @@ namespace jp.ootr.common.Editor
                 var headerCell = CreateHeaderCell(LanguageUtils.ToStr(_visibleLangsSnapshot[c]), c + 1);
                 headerRow.Add(headerCell);
             }
-            table.Add(headerRow);
+            _table.Add(headerRow);
 
             for (var rowIndex = 0; rowIndex < _logicalKeys.Count; rowIndex++)
             {
@@ -591,10 +593,10 @@ namespace jp.ootr.common.Editor
                     row.Add(tf);
                 }
 
-                table.Add(row);
+                _table.Add(row);
             }
 
-            _tableContainer.Add(table);
+            _tableContainer.Add(_table);
             UpdateLangDropdownChoices();
         }
 
@@ -615,9 +617,8 @@ namespace jp.ootr.common.Editor
             ReloadTable(loadFromTarget: false);
             _tableContainer.schedule.Execute(() =>
             {
-                var tableEl = _tableContainer.contentContainer.Children().LastOrDefault();
-                if (tableEl == null) return;
-                var lastRow = tableEl.Children().LastOrDefault();
+                if (_table == null) return;
+                var lastRow = _table.Children().LastOrDefault();
                 if (lastRow != null && _tableContainer is ScrollView sv) sv.ScrollTo(lastRow);
             });
         }
@@ -669,7 +670,11 @@ namespace jp.ootr.common.Editor
             {
                 var keysProp = so.FindProperty("localizationKeys");
                 var valuesProp = so.FindProperty("localizationValues");
-                if (keysProp == null || valuesProp == null) return;
+                if (keysProp == null || valuesProp == null)
+                {
+                    Debug.LogError("[Localization] Cannot save: 'localizationKeys' or 'localizationValues' property not found on target.");
+                    return;
+                }
 
                 Undo.RecordObject(_target, "Edit Localization Data");
                 keysProp.arraySize = pairs.Count;

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -37,6 +37,7 @@ namespace jp.ootr.common.Editor
         [SerializeField] private List<Localization.Language> _explicitlyAddedLanguages = new List<Localization.Language>();
         [SerializeField] private BaseClass _lastLoadedTarget;
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
+        private HashSet<Localization.Language> _originallyLoadedLanguages = new HashSet<Localization.Language>();
         private bool _malformedDataOnLoad;
         private bool _isDirty;
         private int _tableGeneration;
@@ -180,6 +181,7 @@ namespace jp.ootr.common.Editor
                 _keyToLangToValue.Clear();
                 _explicitlyAddedLanguages.Clear();
                 _loadedLanguages.Clear();
+                _originallyLoadedLanguages.Clear();
                 _malformedDataOnLoad = false;
                 _isDirty = false;
                 return;
@@ -197,6 +199,7 @@ namespace jp.ootr.common.Editor
                     _logicalKeys.Clear();
                     _keyToLangToValue.Clear();
                     _loadedLanguages.Clear();
+                    _originallyLoadedLanguages.Clear();
                     _explicitlyAddedLanguages.Clear();
                     _isDirty = false;
                     hasUnsavedChanges = false;
@@ -242,6 +245,7 @@ namespace jp.ootr.common.Editor
                 }
 
                 _logicalKeys = keyOrder;
+                _originallyLoadedLanguages = new HashSet<Localization.Language>(_loadedLanguages);
                 _lastLoadedTarget = _target;
                 _isDirty = false;
                 hasUnsavedChanges = false;
@@ -268,8 +272,10 @@ namespace jp.ootr.common.Editor
                 }
             }
 
-            // 明示的に追加された言語も含める
+            // 明示的に追加された言語・ロード時に存在した言語も含める
             foreach (var lang in _explicitlyAddedLanguages)
+                hasValue.Add(lang);
+            foreach (var lang in _originallyLoadedLanguages)
                 hasValue.Add(lang);
 
             // いずれのキーにも値がない場合は En のみ表示（他は Add Language で追加）
@@ -650,7 +656,9 @@ namespace jp.ootr.common.Editor
             }
 
             var saveLangs = AllLanguages
-                .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l))
+                .Where(l => _loadedLanguages.Contains(l)
+                          || _explicitlyAddedLanguages.Contains(l)
+                          || _originallyLoadedLanguages.Contains(l))
                 .ToList();
             var pairs = new List<(string fullKey, string value)>();
             foreach (var key in _logicalKeys)

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -100,8 +100,16 @@ namespace jp.ootr.common.Editor
         public static void ShowWindowWithTarget(BaseClass target)
         {
             var wnd = GetWindow<LocalizationWindow>();
-            wnd._target = target;
             wnd.titleContent = new GUIContent("Localization");
+
+            if (wnd._isDirty && !EditorUtility.DisplayDialog(
+                    "Unsaved Changes",
+                    "You have unsaved localization changes. Discard them?",
+                    "Discard", "Cancel"))
+                return;
+
+            wnd._target = target;
+            wnd._isDirty = false;
             if (wnd._targetField != null)
                 wnd._targetField.SetValueWithoutNotify(target);
             if (wnd._tableContainer != null)
@@ -167,6 +175,8 @@ namespace jp.ootr.common.Editor
                 _malformedDataOnLoad = true;
                 _logicalKeys.Clear();
                 _keyToLangToValue.Clear();
+                _loadedLanguages.Clear();
+                _explicitlyAddedLanguages.Clear();
                 _isDirty = false;
                 return;
             }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -79,7 +79,6 @@ namespace jp.ootr.common.Editor
             var addKeyBtn = new Button(OnAddKey) { text = "Add Key" };
             var saveBtn = new Button(OnSave) { text = "Save" };
             _langDropdown = new DropdownField { style = { minWidth = 120 } };
-            UpdateLangDropdownChoices();
             var addLangBtn = new Button(OnAddLanguage) { text = "Add" };
             toolbar.Add(addKeyBtn);
             toolbar.Add(saveBtn);
@@ -562,6 +561,7 @@ namespace jp.ootr.common.Editor
                     if (evt.keyCode == KeyCode.Return || evt.keyCode == KeyCode.KeypadEnter)
                     {
                         ApplyOrRevertKeyRename();
+                        keyField.Blur();
                         evt.PreventDefault();
                     }
                 });

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -99,8 +99,8 @@ namespace jp.ootr.common.Editor
         public static void ShowWindowWithTarget(BaseClass target)
         {
             var wnd = GetWindow<LocalizationWindow>();
-            wnd.titleContent = new GUIContent("Localization");
             wnd._target = target;
+            wnd.titleContent = new GUIContent("Localization");
             if (wnd._targetField != null)
                 wnd._targetField.SetValueWithoutNotify(target);
             if (wnd._tableContainer != null)
@@ -154,6 +154,8 @@ namespace jp.ootr.common.Editor
             if (keysProp == null || valuesProp == null || keysProp.arraySize != valuesProp.arraySize)
             {
                 _malformedDataOnLoad = true;
+                _logicalKeys.Clear();
+                _keyToLangToValue.Clear();
                 return;
             }
 
@@ -237,6 +239,7 @@ namespace jp.ootr.common.Editor
         private void OnAddLanguage()
         {
             if (_target == null || _langDropdown == null) return;
+            if (_malformedDataOnLoad) return;
             if (string.IsNullOrEmpty(_langDropdown.value)) return;
             if (!Enum.TryParse<Localization.Language>(_langDropdown.value, out var lang)) return;
             if (!_explicitlyAddedLanguages.Contains(lang))
@@ -373,6 +376,12 @@ namespace jp.ootr.common.Editor
         {
             if (loadFromTarget)
                 LoadFromTarget();
+            if (_malformedDataOnLoad)
+            {
+                _tableContainer.Clear();
+                _tableContainer.Add(new Label("Localization data could not be loaded (malformed or mismatched arrays)."));
+                return;
+            }
             _tableContainer.Clear();
             _columnCellRefs.Clear();
             _columnWidths.Clear();
@@ -455,10 +464,13 @@ namespace jp.ootr.common.Editor
                 keyColumnCells.Add(keyField);
                 keyField.RegisterValueChangedCallback(evt =>
                 {
-                    var newKey = evt.newValue?.Trim() ?? "";
-                    if (string.IsNullOrEmpty(newKey) || newKey == _logicalKeys[idx]) return;
                     var oldKey = _logicalKeys[idx];
-                    if (_keyToLangToValue.ContainsKey(newKey)) return;
+                    var newKey = evt.newValue?.Trim() ?? "";
+                    if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey || _keyToLangToValue.ContainsKey(newKey))
+                    {
+                        keyField.SetValueWithoutNotify(oldKey);
+                        return;
+                    }
                     _keyToLangToValue[newKey] = _keyToLangToValue[oldKey];
                     _keyToLangToValue.Remove(oldKey);
                     _logicalKeys[idx] = newKey;
@@ -496,6 +508,7 @@ namespace jp.ootr.common.Editor
         private void OnAddKey()
         {
             if (_target == null) return;
+            if (_malformedDataOnLoad) return;
             var baseName = "new_key";
             var name = baseName;
             var c = 0;
@@ -517,7 +530,7 @@ namespace jp.ootr.common.Editor
 
             var saveLangs = AllLanguages
                 .Where(l => _loadedLanguages.Contains(l) || _explicitlyAddedLanguages.Contains(l)
-                    || _keyToLangToValue.Values.Any(d => d.ContainsKey(l)))
+                    || _keyToLangToValue.Values.Any(d => d.TryGetValue(l, out var v) && !string.IsNullOrEmpty(v)))
                 .ToList();
             var pairs = new List<(string fullKey, string value)>();
             foreach (var key in _logicalKeys)

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -182,7 +182,7 @@ namespace jp.ootr.common.Editor
                 return;
             }
 
-            var so = new SerializedObject(_target);
+            using var so = new SerializedObject(_target);
             var keysProp = so.FindProperty("localizationKeys");
             var valuesProp = so.FindProperty("localizationValues");
 
@@ -496,6 +496,9 @@ namespace jp.ootr.common.Editor
                 var deleteBtn = new Button(() =>
                 {
                     if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
+                    if (!EditorUtility.DisplayDialog("Delete Key",
+                            $"Delete localization key '{logicalKey}' and all its translations?",
+                            "Delete", "Cancel")) return;
                     _logicalKeys.RemoveAt(idx);
                     _keyToLangToValue.Remove(logicalKey);
                     _isDirty = true;
@@ -598,6 +601,11 @@ namespace jp.ootr.common.Editor
             hasUnsavedChanges = true;
             saveChangesMessage = "You have unsaved localization changes. Save before closing?";
             ReloadTable(loadFromTarget: false);
+            _tableContainer.schedule.Execute(() =>
+            {
+                var last = _tableContainer.contentContainer.Children().LastOrDefault();
+                if (last != null) _tableContainer.ScrollTo(last);
+            });
         }
 
         private void OnSave()
@@ -641,11 +649,11 @@ namespace jp.ootr.common.Editor
                 }
             }
 
-            var so = new SerializedObject(_target);
+            Undo.RecordObject(_target, "Edit Localization Data");
+            using var so = new SerializedObject(_target);
             var keysProp = so.FindProperty("localizationKeys");
             var valuesProp = so.FindProperty("localizationValues");
             if (keysProp == null || valuesProp == null) return;
-
             keysProp.arraySize = pairs.Count;
             valuesProp.arraySize = pairs.Count;
             for (var i = 0; i < pairs.Count; i++)
@@ -654,7 +662,7 @@ namespace jp.ootr.common.Editor
                 valuesProp.GetArrayElementAtIndex(i).stringValue = pairs[i].value;
             }
 
-            so.ApplyModifiedProperties();
+            so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
             if (!EditorUtility.IsPersistent(_target))
             {

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -716,6 +716,9 @@ namespace jp.ootr.common.Editor
             }
             _isDirty = false;
             hasUnsavedChanges = false;
+            _originallyLoadedLanguages = new HashSet<Localization.Language>(_loadedLanguages);
+            _explicitlyAddedLanguages.RemoveAll(l => !_loadedLanguages.Contains(l));
+            ReloadTable(loadFromTarget: false);
         }
     }
 }

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -39,7 +39,7 @@ namespace jp.ootr.common.Editor
         private HashSet<Localization.Language> _loadedLanguages = new HashSet<Localization.Language>();
         private HashSet<Localization.Language> _originallyLoadedLanguages = new HashSet<Localization.Language>();
         private bool _malformedDataOnLoad;
-        private bool _isDirty;
+        [SerializeField] private bool _isDirty;
         private int _tableGeneration;
 
         private DropdownField _langDropdown;
@@ -66,6 +66,22 @@ namespace jp.ootr.common.Editor
         {
             OnSave();
             base.SaveChanges();
+        }
+
+        private void OnEnable()
+        {
+            Undo.undoRedoPerformed += OnUndoRedo;
+        }
+
+        private void OnDisable()
+        {
+            Undo.undoRedoPerformed -= OnUndoRedo;
+        }
+
+        private void OnUndoRedo()
+        {
+            if (_target != null && _tableContainer != null)
+                ReloadTable(loadFromTarget: true);
         }
 
         public void CreateGUI()

--- a/Runtime/Editor/LocalizationWindow.cs
+++ b/Runtime/Editor/LocalizationWindow.cs
@@ -59,6 +59,17 @@ namespace jp.ootr.common.Editor
         private static Color RowOdd => EditorGUIUtility.isProSkin
             ? new Color(0.14f, 0.14f, 0.14f) : new Color(0.78f, 0.78f, 0.78f);
 
+        public override bool hasUnsavedChanges => _isDirty;
+
+        public override string saveChangesMessage =>
+            "You have unsaved localization changes. Save before closing?";
+
+        public override void SaveChanges()
+        {
+            OnSave();
+            base.SaveChanges();
+        }
+
         public void CreateGUI()
         {
             var root = new VisualElement();
@@ -621,7 +632,14 @@ namespace jp.ootr.common.Editor
 
             so.ApplyModifiedPropertiesWithoutUndo();
             EditorUtility.SetDirty(_target);
-            AssetDatabase.SaveAssetIfDirty(_target);
+            if (!EditorUtility.IsPersistent(_target))
+            {
+                Debug.Log("[Localization] Changes saved to in-memory object. Remember to save the scene to persist them.");
+            }
+            else
+            {
+                AssetDatabase.SaveAssetIfDirty(_target);
+            }
             _isDirty = false;
         }
     }

--- a/Runtime/Editor/LocalizationWindow.cs.meta
+++ b/Runtime/Editor/LocalizationWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8e4f2a1b9c7d5e6032148765fedcba90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - baseStyleSheet: {fileID: 7433441132597879392, guid: 61e5f58629691be419d63cded323f448, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -6,6 +6,7 @@ namespace jp.ootr.common.Localization
 {
     public static class LanguageUtils
     {
+#if UNITY_EDITOR
         private static readonly Dictionary<string, Language> StrToLang = new Dictionary<string, Language>
         {
             { "en", Language.En },
@@ -29,17 +30,32 @@ namespace jp.ootr.common.Localization
         {
             return StrToLang.TryGetValue(langStr, out var lang) ? lang : (Language?)null;
         }
+#endif
 
         public static Language GetCurrentLanguage()
         {
             var langStr = VRCPlayerApi.GetCurrentLanguage();
-            var lang = FromStr(langStr);
-            if (lang == null)
+            switch (langStr)
             {
-                Debug.LogWarning($"Unsupported language: {langStr}, fallback to en");
-                return Language.En;
+                case "en": return Language.En;
+                case "fr": return Language.Fr;
+                case "es": return Language.Es;
+                case "it": return Language.It;
+                case "ko": return Language.Ko;
+                case "de": return Language.De;
+                case "ja": return Language.Ja;
+                case "pl": return Language.Pl;
+                case "ru": return Language.Ru;
+                case "pt_BR": return Language.PtBR;
+                case "zh_CN": return Language.ZhCn;
+                case "zh_HK": return Language.ZhHk;
+                case "he": return Language.He;
+                case "tok": return Language.Tok;
+                case "uk": return Language.Uk;
+                default:
+                    Debug.LogWarning($"Unsupported language: {langStr}, fallback to en");
+                    return Language.En;
             }
-            return lang.Value;
         }
 
         public static string ToStr(this Language lang)

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -25,50 +25,21 @@ namespace jp.ootr.common.Localization
             { "uk", Language.Uk },
         };
 
-        public static Language FromStr(string langStr)
+        public static Language? FromStr(string langStr)
         {
-            return StrToLang.TryGetValue(langStr, out var lang) ? lang : Language.En;
+            return StrToLang.TryGetValue(langStr, out var lang) ? lang : (Language?)null;
         }
 
         public static Language GetCurrentLanguage()
         {
             var langStr = VRCPlayerApi.GetCurrentLanguage();
-            switch (langStr)
+            var lang = FromStr(langStr);
+            if (lang == null)
             {
-                case "en":
-                    return Language.En;
-                case "fr":
-                    return Language.Fr;
-                case "es":
-                    return Language.Es;
-                case "it":
-                    return Language.It;
-                case "ko":
-                    return Language.Ko;
-                case "de":
-                    return Language.De;
-                case "ja":
-                    return Language.Ja;
-                case "pl":
-                    return Language.Pl;
-                case "ru":
-                    return Language.Ru;
-                case "pt_BR":
-                    return Language.PtBR;
-                case "zh_CN":
-                    return Language.ZhCn;
-                case "zh_HK":
-                    return Language.ZhHk;
-                case "he":
-                    return Language.He;
-                case "tok":
-                    return Language.Tok;
-                case "uk":
-                    return Language.Uk;
-                default:
-                    Debug.LogWarning($"Unsupported language: {langStr}, fallback to en");
-                    return Language.En;
+                Debug.LogWarning($"Unsupported language: {langStr}, fallback to en");
+                return Language.En;
             }
+            return lang.Value;
         }
 
         public static string ToStr(this Language lang)

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -66,7 +66,7 @@ namespace jp.ootr.common.Localization
                 case Language.Uk:
                     return "uk";
                 default:
-                    Debug.LogWarning($"Unhandled Language value: {lang}, fallback to en.");
+                    Debug.LogWarning($"ToStr: unknown Language value {lang}, falling back to \"en\"");
                     return "en";
             }
         }

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -1,37 +1,10 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using VRC.SDKBase;
 
 namespace jp.ootr.common.Localization
 {
     public static class LanguageUtils
     {
-#if UNITY_EDITOR
-        private static readonly Dictionary<string, Language> StrToLang = new Dictionary<string, Language>
-        {
-            { "en", Language.En },
-            { "fr", Language.Fr },
-            { "es", Language.Es },
-            { "it", Language.It },
-            { "ko", Language.Ko },
-            { "de", Language.De },
-            { "ja", Language.Ja },
-            { "pl", Language.Pl },
-            { "ru", Language.Ru },
-            { "pt_BR", Language.PtBR },
-            { "zh_CN", Language.ZhCn },
-            { "zh_HK", Language.ZhHk },
-            { "he", Language.He },
-            { "tok", Language.Tok },
-            { "uk", Language.Uk },
-        };
-
-        public static Language? FromStr(string langStr)
-        {
-            return StrToLang.TryGetValue(langStr, out var lang) ? lang : (Language?)null;
-        }
-#endif
-
         public static Language GetCurrentLanguage()
         {
             var langStr = VRCPlayerApi.GetCurrentLanguage();

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -1,10 +1,35 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 using VRC.SDKBase;
 
 namespace jp.ootr.common.Localization
 {
     public static class LanguageUtils
     {
+        private static readonly Dictionary<string, Language> StrToLang = new Dictionary<string, Language>
+        {
+            { "en", Language.En },
+            { "fr", Language.Fr },
+            { "es", Language.Es },
+            { "it", Language.It },
+            { "ko", Language.Ko },
+            { "de", Language.De },
+            { "ja", Language.Ja },
+            { "pl", Language.Pl },
+            { "ru", Language.Ru },
+            { "pt_BR", Language.PtBR },
+            { "zh_CN", Language.ZhCn },
+            { "zh_HK", Language.ZhHk },
+            { "he", Language.He },
+            { "tok", Language.Tok },
+            { "uk", Language.Uk },
+        };
+
+        public static Language FromStr(string langStr)
+        {
+            return StrToLang.TryGetValue(langStr, out var lang) ? lang : Language.En;
+        }
+
         public static Language GetCurrentLanguage()
         {
             var langStr = VRCPlayerApi.GetCurrentLanguage();

--- a/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
+++ b/Runtime/jp.ootr.common/Localization/LanguageUtils.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using VRC.SDKBase;
 
 namespace jp.ootr.common.Localization
@@ -66,6 +66,7 @@ namespace jp.ootr.common.Localization
                 case Language.Uk:
                     return "uk";
                 default:
+                    Debug.LogWarning($"Unhandled Language value: {lang}, fallback to en.");
                     return "en";
             }
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Localization Window" button in the editor inspector Debug section to launch an in-editor localization manager.
  * Added a table-based Localization Window for editing localization keys, per-language values, adding languages, resizing columns, and saving changes.

* **Improvements**
  * Cleaner language parsing and selection behavior for more reliable language handling.
  * Adjusted inspector apply behavior to avoid redundant property application during UI rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a full-featured `LocalizationWindow` EditorWindow for managing localization keys and per-language values directly from the Unity editor, along with an "Open Localization Window" button in the `BaseEditor` inspector's Debug section. The localization applier editor is also cleaned up by removing a stray `ApplyModifiedProperties()` call during UI construction.

Key highlights of the implementation:
- The window supports adding/renaming/deleting keys, adding language columns, resizable columns, and explicit Save with undo support via `Undo.RecordObject` + `ApplyModifiedPropertiesWithoutUndo`.
- All issues raised in a thorough prior review round have been addressed: nullable `FromStr`, deferred key-rename validation on `FocusOut`, dirty-check dialogs on target switch and `ShowWindowWithTarget`, `DetachFromPanelEvent` mouse capture cleanup, header-row 20 px delete-button placeholder, `_lastLoadedTarget` serialization for domain-reload survival, `_originallyLoadedLanguages` to prevent language-column loss after save, and a `_tableGeneration` guard against stale closures.
- **One remaining concern:** `.claude/settings.local.json` (a local Claude Code IDE settings file) was accidentally committed and should be removed and added to `.gitignore`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after removing the accidentally committed .claude/settings.local.json file.
- The core localization editor logic is well-implemented and all previously identified bugs have been addressed. The only actionable issue is the committed IDE settings file, which does not affect runtime behavior but should not be in source control. The window's save/undo flow, dirty-tracking, domain-reload survival, and stale-closure guards all look correct.
- `.claude/settings.local.json` should be removed from the repository and added to `.gitignore`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/settings.local.json | Claude Code local settings file accidentally committed; should be in .gitignore and removed from the repository. |
| Runtime/Editor/LocalizationWindow.cs | New 748-line EditorWindow for editing localization data. All previously reported issues (double ReloadTable, stale capture on delete, missing delete button, ResizerOffset float division, dirty-check dialogs, header misalignment, domain reload survival, nullable FromStr, etc.) have been addressed in this revision. |
| Runtime/Editor/BaseEditor.cs | Adds "Open Localization Window" button in the Debug foldout of the inspector, and removes a stray BOM character. Clean, minimal change. |
| Runtime/Editor/LocalizationApplierEditor.cs | Removes the spurious ApplyModifiedProperties() call from CreateInspectorGUI, preventing redundant property application during UI rebuild. |
| Runtime/jp.ootr.common/Localization/LanguageUtils.cs | Switch-case arms condensed to single-line style; a Debug.LogWarning added to the ToStr default branch so unknown Language values are no longer silently swallowed. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Inspector as BaseEditor (Inspector)
    participant LW as LocalizationWindow
    participant Mem as In-Memory State
    participant SO as SerializedObject
    participant Asset as Unity Asset/Scene

    Inspector->>LW: ShowWindowWithTarget(bc)
    LW->>LW: dirty-check dialog (if _isDirty)
    LW->>SO: new SerializedObject(_target)
    SO->>Asset: Read localizationKeys/localizationValues
    SO-->>Mem: Populate _logicalKeys, _keyToLangToValue\n_loadedLanguages, _originallyLoadedLanguages
    SO->>SO: Dispose()
    LW->>LW: ReloadTable() → build UIElements table

    Note over LW,Mem: User edits (key rename / value change / add key / add lang / delete key)
    LW->>Mem: Update _logicalKeys / _keyToLangToValue\n_explicitlyAddedLanguages
    LW->>LW: _isDirty = true, hasUnsavedChanges = true

    LW->>LW: OnSave()
    LW->>Mem: Prune empty values from _keyToLangToValue
    LW->>SO: new SerializedObject(_target)
    LW->>Asset: Undo.RecordObject(_target)
    LW->>SO: Set localizationKeys / localizationValues array
    SO->>Asset: ApplyModifiedPropertiesWithoutUndo()
    SO->>SO: Dispose()
    LW->>Asset: EditorUtility.SetDirty / AssetDatabase.SaveAssetIfDirty
    LW->>Mem: Sync _originallyLoadedLanguages, trim _explicitlyAddedLanguages
    LW->>LW: ReloadTable(loadFromTarget:false)

    Note over LW,Asset: Undo/Redo
    Asset-->>LW: OnUndoRedo → ReloadTable(loadFromTarget:true)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (36)</h3></summary>

1. `Runtime/jp.ootr.common/Localization/LanguageUtils.cs`, line 61-97 ([link](https://github.com/o-tr/jp.ootr.common/blob/e8bb20751c822588353ac6181240ecba018f3bef/Runtime/jp.ootr.common/Localization/LanguageUtils.cs#L61-L97)) 

   **`ToStr` default silently serializes unknown enum values as `"en"`**

   The `default` branch of `ToStr` returns `"en"` without any warning. If a new value is added to the `Language` enum in the future (or if a caller passes a cast integer out of range), the serialized key will use `"en"` as the language prefix. On the next `LoadFromTarget` pass, this will silently overwrite the real English value for the same logical key.

   At minimum, mirror the `GetCurrentLanguage` behaviour and emit a warning:

   ```csharp
   default:
       Debug.LogWarning($"ToStr: unknown Language value {lang}, falling back to \"en\"");
       return "en";
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Runtime/jp.ootr.common/Localization/LanguageUtils.cs
   Line: 61-97

   Comment:
   **`ToStr` default silently serializes unknown enum values as `"en"`**

   The `default` branch of `ToStr` returns `"en"` without any warning. If a new value is added to the `Language` enum in the future (or if a caller passes a cast integer out of range), the serialized key will use `"en"` as the language prefix. On the next `LoadFromTarget` pass, this will silently overwrite the real English value for the same logical key.

   At minimum, mirror the `GetCurrentLanguage` behaviour and emit a warning:

   ```csharp
   default:
       Debug.LogWarning($"ToStr: unknown Language value {lang}, falling back to \"en\"");
       return "en";
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `Runtime/Editor/LocalizationWindow.cs`, line 675-677 ([link](https://github.com/o-tr/jp.ootr.common/blob/bb5ccbcd825948fbca08f79462e6910b1abff3f2/Runtime/Editor/LocalizationWindow.cs#L675-L677)) 

   **`AssetDatabase.SaveAssets()` not called — changes stay in memory**

   `EditorUtility.SetDirty(_target)` marks the asset as modified in Unity's tracking system, but does **not** flush the data to disk. For ScriptableObject-based assets (the most common host for localization data), the `.asset` file will only be written when Unity auto-saves or the user explicitly presses Ctrl+S. A "Save" button in a dedicated editor tool should persist the file immediately.

3. `Runtime/Editor/LocalizationWindow.cs`, line 618-636 ([link](https://github.com/o-tr/jp.ootr.common/blob/bb5ccbcd825948fbca08f79462e6910b1abff3f2/Runtime/Editor/LocalizationWindow.cs#L618-L636)) 

   **`_loadedLanguages` fallback re-read can misclassify prefix for the very same save**

   The guard `if (_loadedLanguages.Count == 0)` re-reads `localizationKeys` from the **already-saved asset on disk** to rebuild `_loadedLanguages`. However, if `OnSave` is invoked multiple times in the same session without any `LoadFromTarget` call in between (e.g. Save → edit in-memory → Save again), `_loadedLanguages` is no longer empty on the second call, so the re-read is skipped and the first path is used correctly.

   The real problem is that this fallback reads from the **current disk state**, not the in-memory state. If `_target` is a new, unsaved asset (zero `localizationKeys` on disk), the loop finds nothing, `_loadedLanguages` remains empty after the block, and the `saveLangs` predicate falls back entirely to the `_explicitlyAddedLanguages` and non-empty value checks. Any language whose values were all cleared back to `""` after being loaded will be dropped from the save — even if the user intended to keep the column with blank strings (e.g., to preserve the structure for a translator).

   Consider always repopulating `_loadedLanguages` from `_keyToLangToValue` at the start of `OnSave` instead of the conditional disk re-read, since `_keyToLangToValue` already contains all language/key pairs that were loaded:

   ```csharp
   // Ensure _loadedLanguages reflects all languages present in the in-memory data
   // (covers domain-reload scenario where _loadedLanguages was cleared)
   foreach (var dict in _keyToLangToValue.Values)
       foreach (var lang in dict.Keys)
           _loadedLanguages.Add(lang);
   ```

4. `Runtime/Editor/LocalizationWindow.cs`, line 502 ([link](https://github.com/o-tr/jp.ootr.common/blob/628e070751327d88bb2f4ce4dabd658a122390e3/Runtime/Editor/LocalizationWindow.cs#L502)) 

   **Language header uses C# enum name instead of ISO code**

   `_visibleLangsSnapshot[c].ToString()` returns the C# identifier name (e.g., `"ZhCn"`, `"PtBR"`, `"En"`), while the "Add Language" dropdown — populated via `LanguageUtils.ToStr(l)` — shows the ISO codes (`"zh_CN"`, `"pt_BR"`, `"en"`). This means a user who added `"zh_CN"` via the dropdown sees the column header labelled `"ZhCn"`, which is visually inconsistent and confusing.

   Use `LanguageUtils.ToStr` to keep the column header consistent with the rest of the UI:

5. `Runtime/Editor/LocalizationWindow.cs`, line 308-309 ([link](https://github.com/o-tr/jp.ootr.common/blob/628e070751327d88bb2f4ce4dabd658a122390e3/Runtime/Editor/LocalizationWindow.cs#L308-L309)) 

   **Dropdown selection is silently reset on every update**

   `_langDropdown.value` is unconditionally set to `choices[0]` on every `UpdateLangDropdownChoices()` call, which happens after each `ReloadTable`. If the user has already selected a specific language from the dropdown (e.g., `"fr"`) and then clicks "Add Key", the table rebuilds, `UpdateLangDropdownChoices` runs, and the dropdown snaps back to the first available language — losing the user's selection.

   Preserve the current selection when the previously chosen value still appears in the updated choices list:

6. `Runtime/Editor/LocalizationWindow.cs`, line 101-110 ([link](https://github.com/o-tr/jp.ootr.common/blob/e14129f9bf3415c79d68011b37c197b9fa0d2a59/Runtime/Editor/LocalizationWindow.cs#L101-L110)) 

   **Unsaved-changes dialog fires when reopening for the same target**

   `wnd._isDirty` is checked without verifying whether `target` differs from the currently loaded `wnd._target`. If the inspector button is clicked while the window already has unsaved edits for **the same** target (e.g. the user opened the window, typed some values, then alt-clicked the inspector button to bring the window forward), the dialog appears with "Discard Changes?" — but no target switch is taking place. The user must click "Discard" just to see the window they were already editing, silently losing their work.

   The guard should be skipped when the incoming target matches what is already loaded:

7. `Runtime/Editor/LocalizationWindow.cs`, line 575-585 ([link](https://github.com/o-tr/jp.ootr.common/blob/e14129f9bf3415c79d68011b37c197b9fa0d2a59/Runtime/Editor/LocalizationWindow.cs#L575-L585)) 

   **`_loadedLanguages` rebuilt from all dict keys silently persists all-empty language columns**

   `_loadedLanguages` is cleared and repopulated at the top of `OnSave` by iterating every key in every `_keyToLangToValue` sub-dictionary, regardless of whether the stored value is empty. Two paths leave empty-string entries in those sub-dictionaries:

   1. **Loading**: `LoadFromTarget` writes `dict[lang] = value` for every serialized entry, including those that already had `value = ""`.
   2. **Editing then clearing**: the `RegisterValueChangedCallback` on each `TextField` writes `d[lang] = evt.newValue`, so a user who types a single character in, say, a French cell and then clears it leaves `Language.Fr → ""` in the dict permanently.

   Because `_loadedLanguages` now contains `Language.Fr`, the `saveLangs` filter's first condition (`_loadedLanguages.Contains(l)`) is satisfied. Every subsequent save writes `"fr.key" = ""` for every logical key, permanently growing the serialized arrays even though the user has no French content.

   The simplest fix is to restrict `_loadedLanguages` (both here and in `LoadFromTarget`) to languages that have at least one **non-empty** value, relying solely on the third condition in `saveLangs` for languages with actual content:

   ```csharp
   // In OnSave – only track languages that have at least one non-empty value
   _loadedLanguages.Clear();
   foreach (var dict in _keyToLangToValue.Values)
       foreach (var kv in dict)
           if (!string.IsNullOrEmpty(kv.Value))
               _loadedLanguages.Add(kv.Key);
   ```

   The same change should be applied in `LoadFromTarget` (line 207):
   ```csharp
   // Only track the language if the serialized value is non-empty
   if (!string.IsNullOrEmpty(value))
       _loadedLanguages.Add(lang.Value);
   ```

8. `Runtime/Editor/LocalizationWindow.cs`, line 633-636 ([link](https://github.com/o-tr/jp.ootr.common/blob/f1f4e9ea5b21eda8e4fcc3efad42831956b289f0/Runtime/Editor/LocalizationWindow.cs#L633-L636)) 

   **Redundant third condition in `saveLangs`**

   `_loadedLanguages` is rebuilt immediately above (lines 623–631) to contain every language that has at least one non-empty value across all keys — which is exactly what the third `Any(...)` predicate tests. Because the rebuild happens unconditionally before this LINQ expression, `_loadedLanguages.Contains(l)` will be `true` whenever the `Any(...)` call would also be `true`, making the third condition permanently redundant. It can be removed without changing behaviour:

9. `Runtime/Editor/LocalizationWindow.cs`, line 671-672 ([link](https://github.com/o-tr/jp.ootr.common/blob/f1f4e9ea5b21eda8e4fcc3efad42831956b289f0/Runtime/Editor/LocalizationWindow.cs#L671-L672)) 

   **`AssetDatabase.SaveAssets()` saves all dirty assets, not just the target**

   `AssetDatabase.SaveAssets()` flushes every asset that Unity has marked dirty — not only `_target`. If the user has other unsaved prefab edits, scene modifications committed to disk assets, or in-progress work in other editor windows, clicking "Save" in the localization window will silently persist all of them. This is typically unexpected for what looks like a single-object save action.

   To scope the save to the target asset only, use `AssetDatabase.SaveAssetIfDirty` (Unity 2020.3+) instead:

   

   If broader Unity version support is required, an alternative is to omit the explicit `SaveAssets` call entirely — `EditorUtility.SetDirty` combined with `ApplyModifiedPropertiesWithoutUndo` is usually sufficient to persist the asset when the project is saved normally, and avoids the side-effect of saving unrelated work.

10. `Runtime/Editor/LocalizationWindow.cs`, line 614-673 ([link](https://github.com/o-tr/jp.ootr.common/blob/1e1e1b6f4a5454c5563f2e20ea173e02fc6a44d3/Runtime/Editor/LocalizationWindow.cs#L614-L673)) 

    **No unsaved-changes warning on window close**

    `_isDirty` is tracked carefully and prompts are shown when switching targets or reopening via the inspector button — but there is no handler for when the user simply closes the window tab (clicks the `×` on the docked panel). Unity calls `OnDestroy` at that point and, more importantly, Unity 2021.2+ exposes the `HasUnsavedChanges` / `SaveChanges` / `saveChangesMessage` API specifically for this scenario, which hooks into Unity's native "Unsaved Changes" close dialog:

    ```csharp
    public override bool hasUnsavedChanges => _isDirty;

    public override string saveChangesMessage =>
        "You have unsaved localization changes. Save before closing?";

    public override void SaveChanges()
    {
        OnSave();
        base.SaveChanges();
    }
    ```

    Without this, any edits the user makes — added keys, renamed keys, edited translations — are silently discarded when they close the window, even though the `_isDirty` infrastructure to prevent that already exists.

11. `Runtime/Editor/LocalizationWindow.cs`, line 669-671 ([link](https://github.com/o-tr/jp.ootr.common/blob/1e1e1b6f4a5454c5563f2e20ea173e02fc6a44d3/Runtime/Editor/LocalizationWindow.cs#L669-L671)) 

    **`AssetDatabase.SaveAssetIfDirty` is a no-op for scene objects**

    `EditorUtility.SetDirty(_target)` correctly marks the target as dirty (for both assets and scene objects). However, `AssetDatabase.SaveAssetIfDirty(_target)` only writes persistent assets (e.g., `ScriptableObject` files on disk); for components on a `GameObject` in a scene it silently does nothing, and the user still has to save the scene manually.

    This is confusing: clicking "Save" in the Localization Window appears to fully persist changes, but for scene-based `BaseClass` instances the data is not actually written to disk until the user explicitly saves the scene (`File → Save` or `Ctrl+S`). Consider displaying a note in the window or in the log when the target is a scene object:

    ```csharp
    so.ApplyModifiedPropertiesWithoutUndo();
    EditorUtility.SetDirty(_target);
    if (!EditorUtility.IsPersistent(_target))
        Debug.Log($"[Localization] Changes saved to in-memory object. Remember to save the scene to persist them.");
    else
        AssetDatabase.SaveAssetIfDirty(_target);
    ```

12. `Runtime/Editor/LocalizationWindow.cs`, line 547-555 ([link](https://github.com/o-tr/jp.ootr.common/blob/979e301ba5fd8fbd05ba8b6aab8d8ee33f19c9c8/Runtime/Editor/LocalizationWindow.cs#L547-L555)) 

    **Same stale-`idx` hazard in the value-changed callback**

    `RegisterValueChangedCallback` fires when the text field value changes. If a `FocusOutEvent` or another interaction flushes a change on a detached `TextField` after a row above it was deleted (shrinking `_logicalKeys`), `_logicalKeys[idx]` at this line will throw `IndexOutOfRangeException` for the same reason as in `ApplyOrRevertKeyRename`.

    Add the same bounds guard at the start of the lambda:

    ```
    if (idx >= _logicalKeys.Count) return;
    ```

13. `Runtime/Editor/LocalizationWindow.cs`, line 512-534 ([link](https://github.com/o-tr/jp.ootr.common/blob/979e301ba5fd8fbd05ba8b6aab8d8ee33f19c9c8/Runtime/Editor/LocalizationWindow.cs#L512-L534)) 

    **`IndexOutOfRangeException` when a delete triggers FocusOut on a higher-indexed row**

    When `_tableContainer.Clear()` is called inside `ReloadTable`, UIToolkit fires a `FocusOutEvent` on any currently focused `VisualElement` before detaching it. If the focused `keyField` belongs to a row whose captured `idx` exceeds the new length of `_logicalKeys`, the list access on line 514 throws `IndexOutOfRangeException`.

    **Reproduction:** Three rows at idx 0, 1, 2. User clicks into the key field of row 2, then presses the delete (✕) button on row 1. The delete closure removes the entry at position 1 from `_logicalKeys` (list length becomes 2) and calls `ReloadTable(loadFromTarget: false)`. `_tableContainer.Clear()` then fires `FocusOutEvent` on the still-focused field with the stale captured value `idx = 2`. Accessing `_logicalKeys` at that position is out of bounds.

    The fix is to add an early bounds check at the top of `ApplyOrRevertKeyRename`:

    ```csharp
    if (idx >= _logicalKeys.Count) return;
    ```

14. `Runtime/Editor/LocalizationWindow.cs`, line 112-116 ([link](https://github.com/o-tr/jp.ootr.common/blob/d9dd9eb7d1514f358b6f433e03b241a4148162bf/Runtime/Editor/LocalizationWindow.cs#L112-L116)) 

    **Same-target re-open silently discards unsaved edits**

    The guard condition `wnd._isDirty && wnd._target != target` only prompts the user when switching to a *different* target. When `ShowWindowWithTarget` is called for the **same** target that is already loaded and dirty (e.g. the user clicks "Open Localization Window" in the inspector for the same object a second time), the condition evaluates to `false` because `wnd._target == target`. Execution falls straight through to lines 118–124, which unconditionally reset `_isDirty = false`, `hasUnsavedChanges = false`, and call `ReloadTable()` — discarding all in-memory edits with no prompt.

    The most common inspector workflow is clicking the button for the same object repeatedly. Consider returning early (just focusing the window) when the same target is already loaded:

    ```csharp
    public static void ShowWindowWithTarget(BaseClass target)
    {
        var wnd = GetWindow<LocalizationWindow>();
        wnd.titleContent = new GUIContent("Localization");

        // Same target already loaded — just bring the window to focus
        if (wnd._target == target)
        {
            wnd.Show();
            wnd.Focus();
            return;
        }

        if (wnd._isDirty && !EditorUtility.DisplayDialog(
                "Unsaved Changes",
                "You have unsaved localization changes. Discard them?",
                "Discard", "Cancel"))
            return;

        wnd._target = target;
        wnd._isDirty = false;
        wnd.hasUnsavedChanges = false;
        if (wnd._targetField != null)
            wnd._targetField.SetValueWithoutNotify(target);
        if (wnd._tableContainer != null)
            wnd.ReloadTable();
    }
    ```

15. `Runtime/Editor/LocalizationWindow.cs`, line 512-520 ([link](https://github.com/o-tr/jp.ootr.common/blob/d9dd9eb7d1514f358b6f433e03b241a4148162bf/Runtime/Editor/LocalizationWindow.cs#L512-L520)) 

    **No user feedback when rename is rejected due to key collision**

    When `_keyToLangToValue.ContainsKey(newKey)` is `true` (a key with that name already exists), `ApplyOrRevertKeyRename` silently resets the `TextField` to the old value via `keyField.SetValueWithoutNotify(oldKey)`. The user sees the field snap back with no explanation, which can be confusing — especially when the conflicting key is far away in a long list.

    Consider adding a brief `Debug.LogWarning` or a tooltip to indicate why the rename was rejected:

    ```csharp
    if (string.IsNullOrWhiteSpace(newKey) || newKey == oldKey)
    {
        keyField.SetValueWithoutNotify(oldKey);
        return;
    }
    if (_keyToLangToValue.ContainsKey(newKey))
    {
        Debug.LogWarning($"[Localization] Cannot rename '{oldKey}' to '{newKey}': a key with that name already exists.");
        keyField.SetValueWithoutNotify(oldKey);
        return;
    }
    ```

16. `Runtime/Editor/LocalizationWindow.cs`, line 40 ([link](https://github.com/o-tr/jp.ootr.common/blob/d9dd9eb7d1514f358b6f433e03b241a4148162bf/Runtime/Editor/LocalizationWindow.cs#L40)) 

    **`_isDirty` lost on domain reload — dirty guard always false after recompile**

    `_isDirty` is a plain `private bool` field (no `[SerializeField]`), so it is always `false` after a domain reload / script recompilation. `hasUnsavedChanges` (from `EditorWindow`) IS persisted by Unity and may still be `true` after a reload, showing the unsaved-changes indicator in the title bar — but the internal guard in `_targetField.RegisterValueChangedCallback` (line 148) checks `_isDirty`, not `hasUnsavedChanges`. After a domain reload, that guard will never fire, so the confirmation dialog before discarding edits is silently suppressed.

    In practice the in-memory `_logicalKeys`/`_keyToLangToValue` data is also lost on a domain reload (both fields are non-serialized), so `LoadFromTarget()` reloads from disk and correctly resets `hasUnsavedChanges = false` — making this a latent rather than currently observable bug. However, if `_isDirty` is ever evaluated before `LoadFromTarget` completes (e.g. in `ShowWindowWithTarget` when `_tableContainer` is still null), the missing guard could matter. Marking it `[SerializeField]` keeps the in-memory flag consistent with `hasUnsavedChanges`:

    ```csharp
    [SerializeField] private bool _isDirty;
    ```

17. `Runtime/Editor/LocalizationWindow.cs`, line 644-657 ([link](https://github.com/o-tr/jp.ootr.common/blob/3270dcb24ce5ee7a42ac6b601c4d3c622c5431a3/Runtime/Editor/LocalizationWindow.cs#L644-L657)) 

    **Ctrl+Z after save desyncs in-memory state from disk**

    `so.ApplyModifiedProperties()` creates a Unity undo entry. If the user presses Ctrl+Z after saving, Unity reverts the serialized asset to its pre-save state on disk, but the window's in-memory data (`_logicalKeys`, `_keyToLangToValue`) is **not** reverted — only the `SerializedObject` on disk is. The result is:

    1. After save: disk = saved state, memory = saved state, `_isDirty = false`
    2. After Ctrl+Z: disk = pre-save state, memory = saved state, `_isDirty = false`
    3. The table still shows the post-save (stale) data with no dirty indicator. The user cannot tell the undo happened.

    Clicking "Save" again rewrites the same post-save data, effectively making the undo a no-op from the user's perspective.

    Consider refreshing the in-memory state by calling `ReloadTable()` after a successful save, or suppressing Unity's undo entry for the apply by using a pattern that records before mutation:

    ```csharp
    Undo.RecordObject(_target, "Edit Localization Data");
    // mutate arrays on so ...
    so.ApplyModifiedPropertiesWithoutUndo(); // only the Undo.RecordObject entry is created
    ```

    This gives a single, clean undo step and keeps in-memory state consistent with disk.

18. `Runtime/Editor/LocalizationWindow.cs`, line 185-200 ([link](https://github.com/o-tr/jp.ootr.common/blob/3270dcb24ce5ee7a42ac6b601c4d3c622c5431a3/Runtime/Editor/LocalizationWindow.cs#L185-L200)) 

    **`SerializedObject` instances not disposed**

    Both `LoadFromTarget` (line 185) and `OnSave` (line 644) create `new SerializedObject(_target)` without wrapping them in a `using` block. `SerializedObject` implements `IDisposable`; not disposing it can cause the underlying native object to accumulate until GC finalizes it. During frequent reloads or rapid saves this can build up in the editor.

    

    Apply the same pattern in `OnSave` at line 644:
    ```csharp
    using var so = new SerializedObject(_target);
    ```

19. `Runtime/Editor/LocalizationWindow.cs`, line 496-504 ([link](https://github.com/o-tr/jp.ootr.common/blob/3270dcb24ce5ee7a42ac6b601c4d3c622c5431a3/Runtime/Editor/LocalizationWindow.cs#L496-L504)) 

    **No confirmation dialog before deleting a key**

    Clicking the `✕` button immediately removes the key and all its translations from `_logicalKeys` and `_keyToLangToValue` with no confirmation prompt. A single misclick permanently deletes potentially many translations (they are only recoverable via "Reload from target" by navigating away and back, which is not obvious).

    Consider adding a quick confirmation:

    ```csharp
    var deleteBtn = new Button(() =>
    {
        if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;
        if (!EditorUtility.DisplayDialog("Delete Key",
                $"Delete localization key '{logicalKey}' and all its translations?",
                "Delete", "Cancel")) return;
        _logicalKeys.RemoveAt(idx);
        _keyToLangToValue.Remove(logicalKey);
        _isDirty = true;
        hasUnsavedChanges = true;
        saveChangesMessage = "You have unsaved localization changes. Save before closing?";
        ReloadTable(loadFromTarget: false);
    }) { text = "✕" };
    ```

20. `Runtime/Editor/LocalizationWindow.cs`, line 652-656 ([link](https://github.com/o-tr/jp.ootr.common/blob/914a1cba4091e8d2b2e068aea24900c9eddd6c5d/Runtime/Editor/LocalizationWindow.cs#L652-L656)) 

    **`Undo.RecordObject` called before null guard — stale undo entry on failure**

    `Undo.RecordObject` is called on line 652 before the null-check for `keysProp`/`valuesProp` on line 656. If either property is not found and the method returns early, an undo snapshot has already been recorded even though no data was modified. The user's undo stack now contains a spurious entry that restores the object to an identical state, which is invisible but consumes an undo slot and can cause confusing Ctrl+Z behaviour.

    Move the null check above `Undo.RecordObject`:

    

    Or more cleanly, perform the null check using the already-created `SerializedObject`:

    ```csharp
    Undo.RecordObject(_target, "Edit Localization Data");
    using var so = new SerializedObject(_target);
    var keysProp = so.FindProperty("localizationKeys");
    var valuesProp = so.FindProperty("localizationValues");
    if (keysProp == null || valuesProp == null)
    {
        // undo the recorded-but-unused snapshot
        Undo.RevertAllDownToGroup(Undo.GetCurrentGroup());
        return;
    }
    ```

21. `Runtime/Editor/LocalizationWindow.cs`, line 87 ([link](https://github.com/o-tr/jp.ootr.common/blob/c0533692deb2025e4a101e022c5c68bf3f87033d/Runtime/Editor/LocalizationWindow.cs#L87)) 

    **`_isDirty` resets to `false` on domain reload — diverges from `hasUnsavedChanges`**

    `_isDirty` is a plain non-serialized field. After any domain reload (e.g., script recompilation), it is reset to its default value `false`. Unity's `EditorWindow.hasUnsavedChanges`, however, is serialized by Unity and may retain `true` from before the reload.

    This creates a split state: the window will display the "unsaved changes" indicator (because `hasUnsavedChanges == true`) and Unity will call `SaveChanges()` on window close, but any attempt by the user to switch targets or open a new target via the inspector button will **not** show the "Discard unsaved changes?" prompt — because both `ShowWindowWithTarget` and the `_targetField` callback gate on `_isDirty`, not on `hasUnsavedChanges`. The user's pre-reload edits are silently discarded without warning.

    Marking `_isDirty` as `[SerializeField]` aligns its lifetime with `hasUnsavedChanges` across domain reloads:

22. `Runtime/Editor/LocalizationWindow.cs`, line 686-688 ([link](https://github.com/o-tr/jp.ootr.common/blob/c0533692deb2025e4a101e022c5c68bf3f87033d/Runtime/Editor/LocalizationWindow.cs#L686-L688)) 

    **Empty-string entries serialized for every key in explicitly-added-but-unused language columns**

    `saveLangs` includes every language in `_explicitlyAddedLanguages`, regardless of whether that language has any non-empty value. For each such language, the inner loop (line 693) writes an empty-string entry for **every** logical key. A table with 50 keys and 3 explicitly-added-but-never-filled language columns would silently append 150 empty-string pairs to the serialized arrays on every save.

    These empty entries are benign on reload (they parse to `""` values and are loaded into the in-memory dictionaries), but they grow the serialized asset proportionally and make the raw data harder to audit.

    Consider filtering out entries where both the value is empty and the language was not present in the loaded data:

    ```csharp
    foreach (var lang in saveLangs)
    {
        var value = dict.TryGetValue(lang, out var v) ? v : "";
        // Skip entirely-empty entries for languages that were never populated
        if (string.IsNullOrEmpty(value) && !_loadedLanguages.Contains(lang)) continue;
        var langPrefix = LanguageUtils.ToStr(lang);
        ...
    }
    ```

23. `Runtime/Editor/LocalizationApplierEditor.cs`, line 44-52 ([link](https://github.com/o-tr/jp.ootr.common/blob/c0533692deb2025e4a101e022c5c68bf3f87033d/Runtime/Editor/LocalizationApplierEditor.cs#L44-L52)) 

    **`serializedObject.Update()` called but `ApplyModifiedProperties` no longer called**

    `serializedObject.Update()` is called at line 21 to pull the current serialized state into the buffer. The removal of `serializedObject.ApplyModifiedProperties()` at the end of `CreateInspectorGUI` is correct for the initial build (there are no user changes to flush). However, the remaining `prop.NextVisible` iteration reads from the `SerializedObject` buffer without issue.

    One edge case: if `CreateInspectorGUI` is called while there are already pending in-memory modifications on `serializedObject` (unlikely but possible if it is reused across rebuilds), removing the `ApplyModifiedProperties` call means those pending changes would be silently dropped. This is very low risk in practice, but worth noting that the manual `ApplyModifiedProperties` call in `CreateDropdownField`'s callback (line 101) still correctly flushes user-driven changes.

24. `Runtime/Editor/LocalizationWindow.cs`, line 619-627 ([link](https://github.com/o-tr/jp.ootr.common/blob/6711487858d49a366946873e32b686db8d59e3fb/Runtime/Editor/LocalizationWindow.cs#L619-L627)) 

    **`FocusOutEvent` double-fires after Enter key rename**

    Both `FocusOutEvent` and `KeyDownEvent` are registered to call `ApplyOrRevertKeyRename`. When the user presses Enter to commit a rename:

    1. `KeyDownEvent` fires → `ApplyOrRevertKeyRename` runs and renames the key (updating `_logicalKeys[idx]` and `logicalKey` to the new value).
    2. The Enter key typically moves focus away, firing `FocusOutEvent` on the same field → `ApplyOrRevertKeyRename` runs again with `newKey == oldKey`, so it hits the early-return and calls `keyField.SetValueWithoutNotify(oldKey)`.

    The second call is harmless *today* because `newKey == oldKey` short-circuits. However, if the rename logic ever becomes more expensive (or has side effects before the guard), this double invocation will be a latent bug. Guard explicitly against double application by clearing the field's pending edit state or checking whether the value has already been committed:

    ```csharp
    keyField.RegisterCallback<KeyDownEvent>(evt =>
    {
        if (evt.keyCode == KeyCode.Return || evt.keyCode == KeyCode.KeypadEnter)
        {
            ApplyOrRevertKeyRename();
            keyField.Blur(); // explicitly removes focus so FocusOutEvent fires but is a no-op
            evt.PreventDefault();
        }
    });
    ```

25. `Runtime/Editor/LocalizationWindow.cs`, line 727-743 ([link](https://github.com/o-tr/jp.ootr.common/blob/6711487858d49a366946873e32b686db8d59e3fb/Runtime/Editor/LocalizationWindow.cs#L727-L743)) 

    **`OnSave` early-return leaks the `SerializedObject`**

    If `keysProp` or `valuesProp` is `null`, the `return` on line 732 exits the `try` block, but `so.Dispose()` in the `finally` block is still guaranteed to be called by the CLR — so there is no actual resource leak. However, `Undo.RecordObject` has already been called on line 734 before the guard, meaning an undo snapshot is taken even when nothing is actually saved. That orphaned undo entry will confuse users (Ctrl+Z will undo to a state that was never reached).

    Move the `null` check **before** `Undo.RecordObject`:

    ```csharp
    var so = new SerializedObject(_target);
    try
    {
        var keysProp = so.FindProperty("localizationKeys");
        var valuesProp = so.FindProperty("localizationValues");
        if (keysProp == null || valuesProp == null) return; // early-exit before recording undo

        Undo.RecordObject(_target, "Edit Localization Data");
        keysProp.arraySize = pairs.Count;
        ...
    ```

26. `Runtime/Editor/LocalizationWindow.cs`, line 142 ([link](https://github.com/o-tr/jp.ootr.common/blob/6711487858d49a366946873e32b686db8d59e3fb/Runtime/Editor/LocalizationWindow.cs#L142)) 

    **`UpdateLangDropdownChoices` called before data is loaded in `CreateGUI`**

    On line 142, `UpdateLangDropdownChoices()` is called immediately after the dropdown is constructed but before any target data has been loaded. At this point `_logicalKeys` is empty and `GetVisibleLanguages()` returns `[]`, so **all** languages are offered as available choices in the dropdown. 

    When `_target != null` (e.g. after a domain reload with a serialized target), `ReloadTable()` runs at line 156 and calls `UpdateLangDropdownChoices()` again with the correct state — so the correct choices are displayed after the first frame. For the `_target == null` path the initial population is fine. The extra call on line 142 is redundant and can be removed to avoid a transient all-languages dropdown on first paint:

27. `Runtime/Editor/LocalizationWindow.cs`, line 732-733 ([link](https://github.com/o-tr/jp.ootr.common/blob/04a4a8cdabe89acd7d80388eb0694b07d884a2f4/Runtime/Editor/LocalizationWindow.cs#L732-L733)) 

    **`OnSave` silently exits without re-enabling save after early return**

    When `keysProp == null || valuesProp == null` (line 732), the method returns inside the `try` block without clearing `_isDirty` or `hasUnsavedChanges`. The `finally` correctly disposes `so`, but the window keeps showing "Save" as needed and `hasUnsavedChanges` stays `true`. On the next close attempt Unity will prompt the user to save, and they will end up in an infinite loop if the properties are permanently absent.

    Consider adding an error log and resetting the dirty state so the user is informed and the window does not keep prompting:

    ```csharp
    if (keysProp == null || valuesProp == null)
    {
        Debug.LogError("[Localization] Cannot save: 'localizationKeys' or 'localizationValues' property not found on target.");
        return;
    }
    ```

    And reset `_isDirty = false; hasUnsavedChanges = false;` only on a successful save (current behaviour), but ensure the user gets clear feedback when the save path fails.

28. `Runtime/Editor/LocalizationWindow.cs`, line 705-726 ([link](https://github.com/o-tr/jp.ootr.common/blob/9710019e0cfe28b887e5056e0e33ada8e721fb15/Runtime/Editor/LocalizationWindow.cs#L705-L726)) 

    **Explicitly-added but value-less languages are silently dropped on save**

    `saveLangs` (line 705–707) includes languages from `_explicitlyAddedLanguages`. For each `(key, lang)` pair, the write is guarded by:

    ```csharp
    if (string.IsNullOrEmpty(value) && !_loadedLanguages.Contains(lang)) continue;
    ```

    `_loadedLanguages` was just recomputed (lines 695–703) to contain only languages with **at least one non-empty value**. If a language was explicitly added (via the "Add" button) but no values have been entered yet for any key, it is in `_explicitlyAddedLanguages` but NOT in `_loadedLanguages`. Every `(key, lang)` pair for that language has an empty value, so every pair is skipped. After saving, the language column effectively disappears — `_explicitlyAddedLanguages` is not cleared, but the serialized data does not contain the language, and on the next load from target the column won't be restored.

    A user who adds a language column, fills in one value, deletes that value, and then saves loses the column with no warning.

    Consider persisting the column by writing at least one empty entry per key for explicitly-added languages, or prompting the user when a save would drop a visible column they added.

29. `Runtime/Editor/LocalizationWindow.cs`, line 480-481 ([link](https://github.com/o-tr/jp.ootr.common/blob/9710019e0cfe28b887e5056e0e33ada8e721fb15/Runtime/Editor/LocalizationWindow.cs#L480-L481)) 

    **Off-by-one: last language column width is never persisted to `_langColumnWidths`**

    The condition is:

    ```csharp
    else if (columnIndex <= _visibleLangsSnapshot.Count)
        SetLangColumnWidth(_visibleLangsSnapshot[columnIndex - 1], width);
    ```

    Valid column indices for language columns are `1` through `_visibleLangsSnapshot.Count` (inclusive). `columnIndex - 1` therefore ranges from `0` to `_visibleLangsSnapshot.Count - 1`, which are all valid indices into `_visibleLangsSnapshot`. So the condition is actually correct for persisting column widths.

    However, `_columnWidths` only has `1 + _visibleLangsSnapshot.Count` entries (indices 0 through N). The assignment `_columnWidths[columnIndex] = width` at line 477 will throw an `IndexOutOfRangeException` if `columnIndex` equals `_visibleLangsSnapshot.Count`, because `_columnWidths` has exactly `_visibleLangsSnapshot.Count + 1` elements (valid indices 0–N), making index N valid. Wait — re-checking: `_columnWidths.Add(_keyColumnWidth)` (index 0) + N language entries = N+1 total entries (indices 0 to N). `columnIndex` at most equals N. Index N is valid.

    The actual issue is more subtle: the resizer for column `columnIndex` is created with `CreateResizer(columnIndex)`, but `_resizeStartWidth = _columnWidths[columnIndex]` at line 417. If a resizer fires while `_columnWidths` is in a stale state (after `ReloadTable` rebuilt it with a different number of columns), this read will silently use a wrong width or throw `ArgumentOutOfRangeException`. Consider caching the starting width at drag-start time more defensively:

    ```csharp
    _resizeStartWidth = columnIndex < _columnWidths.Count ? _columnWidths[columnIndex] : 0f;
    ```

30. `Runtime/Editor/LocalizationWindow.cs`, line 639-652 ([link](https://github.com/o-tr/jp.ootr.common/blob/9710019e0cfe28b887e5056e0e33ada8e721fb15/Runtime/Editor/LocalizationWindow.cs#L639-L652)) 

    **Stale closure can write to wrong dictionary key after rename + rebuild**

    `logicalKey` is captured from the for-loop scope and is correctly updated by `ApplyOrRevertKeyRename` (line 614). However, this value-changed callback is registered on a `TextField` that may stay attached to the panel briefly after a `ReloadTable(loadFromTarget: false)` call rebuilds the table (e.g., triggered by `OnAddKey`). In that window, a pending `ChangeEvent` from the old `TextField` can fire, look up `_keyToLangToValue[key]` using the *current* `_logicalKeys[idx]` (which now belongs to a newly-rebuilt row), and write a value under a key the user never intended to edit.

    The guard `if (idx >= _logicalKeys.Count || _logicalKeys[idx] != logicalKey) return;` at line 641 protects against the case where the row index moved, but it does **not** protect against the case where after a rename the old callback fires again and `_logicalKeys[idx] == logicalKey` still holds true.

    Consider introducing a generation counter that is incremented on every `ReloadTable` call and captured in each closure, so any callback from a previous generation is immediately discarded:

    ```csharp
    private int _tableGeneration;
    // in ReloadTable:
    _tableGeneration++;
    var gen = _tableGeneration;
    // in RegisterValueChangedCallback:
    if (gen != _tableGeneration) return;
    ```

31. `Runtime/Editor/LocalizationWindow.cs`, line 702-711 ([link](https://github.com/o-tr/jp.ootr.common/blob/86c84f7630e60416366418d30d83c48f21a0c706/Runtime/Editor/LocalizationWindow.cs#L702-L711)) 

    **`_loadedLanguages` rebuilt in `OnSave` but never updated after value edits**

    `_loadedLanguages` is rebuilt at the start of `OnSave` by iterating all values in `_keyToLangToValue`. While this correctly captures languages with non-empty values at save time, it creates a subtle inconsistency: a language that was originally **loaded** from the asset (and thus should be preserved) but whose **all** values have been cleared by the user will be silently excluded from both `_loadedLanguages` (no non-empty values) and `_explicitlyAddedLanguages` (it was loaded, not added via the button). As a result, all entries for that language are dropped on save with no warning to the user.

    Consider tracking languages that were present at load time in a separate persistent set (e.g. `_originallyLoadedLanguages`) that is NOT cleared on save, so the user has to explicitly delete a language column rather than accidentally losing it by clearing values:

    ```csharp
    // In LoadFromTarget, after populating _loadedLanguages:
    _originallyLoadedLanguages = new HashSet<Localization.Language>(_loadedLanguages);

    // In OnSave, use union of original + current non-empty + explicitly added:
    var saveLangs = AllLanguages
        .Where(l => _loadedLanguages.Contains(l)
                 || _explicitlyAddedLanguages.Contains(l)
                 || _originallyLoadedLanguages.Contains(l))
        .ToList();
    ```

32. `Runtime/Editor/LocalizationWindow.cs`, line 717-718 ([link](https://github.com/o-tr/jp.ootr.common/blob/5b0358ce25e5d6a2b810abde9d23fb350f59264e/Runtime/Editor/LocalizationWindow.cs#L717-L718)) 

    **`_originallyLoadedLanguages` never refreshed after a save**

    `_originallyLoadedLanguages` is populated once inside `LoadFromTarget` (line 248) and is never updated when `OnSave` completes. It is then consulted inside `GetVisibleLanguages()` (line 278) and `saveLangs` (line 661) on every subsequent save — even after multiple edits and saves.

    **Practical consequence:** if the original asset had a French column, the user clears every French value and saves, `_originallyLoadedLanguages` still contains `Language.Fr`. On every future save (until the window is closed and reopened), French is included in `saveLangs` and written back to the asset as empty-string entries. The user has no way to permanently remove a language once the window has loaded it, since the "reset" only happens on the next `LoadFromTarget` call.

    Updating `_originallyLoadedLanguages` at the end of `OnSave` to reflect the newly persisted state would fix this:

    ```csharp
    _isDirty = false;
    hasUnsavedChanges = false;
    // Refresh so future saves don't re-include languages the user intentionally cleared
    _originallyLoadedLanguages = new HashSet<Localization.Language>(_loadedLanguages);
    ```

33. `.claude/settings.local.json`, line 1-7 ([link](https://github.com/o-tr/jp.ootr.common/blob/52af82f1e9efb2689056c8ccdc2f9d8c66dedd1b/.claude/settings.local.json#L1-L7)) 

    **Development artifact committed to version control**

    `.claude/settings.local.json` is a Claude Code IDE configuration file that grants shell-command permissions specifically for this developer's local session. Committing it to the repository means:

    1. It affects every contributor who uses Claude Code on this repo, silently granting `Bash(xargs grep:*)` permissions without their knowledge.
    2. It pollutes the repository with editor-specific tooling state, similar to committing `.idea/` or `.vscode/` files — the convention is to list these in `.gitignore`.

    Consider adding `.claude/settings.local.json` (or `.claude/` entirely) to `.gitignore` and removing this file from the commit.

34. `Runtime/Editor/LocalizationWindow.cs`, line 717-721 ([link](https://github.com/o-tr/jp.ootr.common/blob/52af82f1e9efb2689056c8ccdc2f9d8c66dedd1b/Runtime/Editor/LocalizationWindow.cs#L717-L721)) 

    **Undo reverts data but window does not update**

    After `OnSave`, `Undo.RecordObject` correctly snapshots `_target` before the write. If the user presses Ctrl+Z, Unity restores `_target`'s serialized arrays to the pre-save state. However, the in-memory structures (`_logicalKeys`, `_keyToLangToValue`) are never refreshed — `ReloadTable(loadFromTarget: false)` at line 721 explicitly skips re-reading from `_target`. The result is that the window continues to display the post-save data while the underlying asset has been silently reverted, creating a permanent desync until the user manually switches the target and back.

    A `SaveChanges`/undo integration requires either:
    - Calling `ReloadTable(loadFromTarget: true)` (full reload from asset) after save, or
    - Registering an `Undo.undoRedoPerformed` callback that reloads the table:

    ```csharp
    private void OnEnable()
    {
        Undo.undoRedoPerformed += OnUndoRedo;
    }

    private void OnDisable()
    {
        Undo.undoRedoPerformed -= OnUndoRedo;
    }

    private void OnUndoRedo()
    {
        if (_target != null)
            ReloadTable(loadFromTarget: true);
    }
    ```

35. `Runtime/Editor/LocalizationWindow.cs`, line 42 ([link](https://github.com/o-tr/jp.ootr.common/blob/52af82f1e9efb2689056c8ccdc2f9d8c66dedd1b/Runtime/Editor/LocalizationWindow.cs#L42)) 

    **`_isDirty` not serialized — dirty guard bypassed after domain reload**

    `_isDirty` is a plain `private bool` (not `[SerializeField]`). After any domain reload (e.g. script compilation), the field is reset to `false`. If the user had unsaved edits before the reload, `_isDirty` will be `false` on the next call to `ShowWindowWithTarget` or on a target change via the `ObjectField` — the "Discard unsaved changes?" dialog will not appear. Combined with the fact that `_logicalKeys` and `_keyToLangToValue` are also not serialized and are therefore wiped on reload, the user gets silent data loss with no indication.

    While the in-memory data is unavoidably lost (those collections are not serialized), at minimum `_isDirty` should be made `[SerializeField]` so that the dirty-warning dialog fires when the user switches target after a reload cycle — even if at that point there is nothing left to protect:

    ```csharp
    [SerializeField] private bool _isDirty;
    ```

    This keeps the invariant consistent: `hasUnsavedChanges` (which Unity's `EditorWindow` infrastructure does preserve across reloads) always aligns with `_isDirty`.

36. `Runtime/Editor/LocalizationWindow.cs`, line 667-681 ([link](https://github.com/o-tr/jp.ootr.common/blob/05785bd171e3e9b78701d47334c035bd4c8203b7/Runtime/Editor/LocalizationWindow.cs#L667-L681)) 

    **Empty-value dict entries accumulate and permanently leak into `saveLangs`**

    `d[lang1] = evt.newValue` is written on every keystroke, but there is no corresponding removal when the user clears the field back to `""`. Once any character is typed in a language cell, `_keyToLangToValue[key]` permanently contains that language key — even if the final value is empty.

    `OnSave` builds `_loadedLanguages` by scanning for non-empty values (lines 724–732), but `saveLangs` includes `_explicitlyAddedLanguages` *and* `_originallyLoadedLanguages` as well (lines 734–738). For languages that are neither of those two, the only route in is through `_loadedLanguages`. A touched-then-cleared cell leaves an empty string in the dict, so `_loadedLanguages` never picks it up — this part is fine.

    However, `_originallyLoadedLanguages` is **refreshed** from `_loadedLanguages` at the end of `OnSave` (line 795). If a language was originally loaded, its values were all cleared, and then saved, it would no longer be in `_originallyLoadedLanguages`. On the *next* save it would only survive if it has non-empty values in `_loadedLanguages` — which won't be the case. So save → clear → save would silently drop the language, inconsistent with the "always preserve originally-loaded languages" guarantee.

    Consider purging zero-value entries from the dict on save before rebuilding `_loadedLanguages`:

    ```csharp
    // In OnSave, before the _loadedLanguages rebuild
    foreach (var dict in _keyToLangToValue.Values)
    {
        var emptyKeys = dict.Where(kv => string.IsNullOrEmpty(kv.Value))
                            .Select(kv => kv.Key).ToList();
        foreach (var k in emptyKeys)
            dict.Remove(k);
    }
    ```
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .claude/settings.local.json
Line: 1-7

Comment:
**Claude Code settings file accidentally committed**

`.claude/settings.local.json` is a local Claude Code IDE settings file that is specific to the machine/developer who ran the AI assistant. It should not be committed to the repository, as:

1. It exposes information about the local tooling used.
2. It can conflict with other contributors' local Claude Code configurations.
3. It is not part of the project's source code.

This file should be removed from the repository and added to `.gitignore`:

```
# .gitignore
.claude/settings.local.json
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["指摘事項に対応"](https://github.com/o-tr/jp.ootr.common/commit/5d8278e6c8f5dcad78058075a419800226dc0273)</sub>

<!-- /greptile_comment -->