### PR TITLE
EditorOnlyMonoBehaviourを導入し、ビルド時の破棄処理を統合

### DIFF
--- a/Runtime/Editor/BaseEditor.cs
+++ b/Runtime/Editor/BaseEditor.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Generic;
 using jp.ootr.common.ColorSchema;
 using jp.ootr.common.Localization;
 using UnityEditor;
@@ -8,6 +9,7 @@ using UnityEditor.Build.Reporting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Object = UnityEngine.Object;
 
@@ -38,6 +40,7 @@ namespace jp.ootr.common.Editor
 
         public override VisualElement CreateInspectorGUI()
         {
+            Root.Unbind();
             Root.Clear();
             ShowScriptName();
             Root.Add(ShowLogLevelPicker());
@@ -49,6 +52,7 @@ namespace jp.ootr.common.Editor
             ShowUtilities();
 
             ShowDebug();
+            Root.Bind(serializedObject);
             return Root;
         }
 
@@ -129,6 +133,7 @@ namespace jp.ootr.common.Editor
     {
         static PlayModeNotifier()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
 
             var classes = ComponentUtils.GetAllComponents<BaseClass>();
@@ -229,18 +234,23 @@ namespace jp.ootr.common.Editor
         {
             if (target == null) return;
             var targets = target.GetComponentsInChildren<LocalizationApplierTextMeshPro>(true);
+            var filteredTargets = new List<LocalizationApplierTextMeshPro>();
+            foreach (var t in targets)
+            {
+                if (t != null) filteredTargets.Add(t);
+            }
+
             var baseClassSo = new SerializedObject(target);
             baseClassSo.Update();
             var localizationTargetKeys = baseClassSo.FindProperty(nameof(BaseClass.localizationTargetKeys));
             var localizationTargets = baseClassSo.FindProperty(nameof(BaseClass.localizationTargets));
             if (localizationTargetKeys == null || localizationTargets == null) return;
-            localizationTargetKeys.arraySize = targets.Length;
-            localizationTargets.arraySize = targets.Length;
-            for (var i = 0; i < targets.Length; i++)
+            localizationTargetKeys.arraySize = filteredTargets.Count;
+            localizationTargets.arraySize = filteredTargets.Count;
+            for (var i = 0; i < filteredTargets.Count; i++)
             {
-                if (targets[i] == null) continue;
-                localizationTargetKeys.GetArrayElementAtIndex(i).stringValue = targets[i].TextKey;
-                localizationTargets.GetArrayElementAtIndex(i).objectReferenceValue = targets[i].TextMeshProUGUI;
+                localizationTargetKeys.GetArrayElementAtIndex(i).stringValue = filteredTargets[i].TextKey;
+                localizationTargets.GetArrayElementAtIndex(i).objectReferenceValue = filteredTargets[i].TextMeshProUGUI;
             }
 
             baseClassSo.ApplyModifiedProperties();

--- a/Runtime/Editor/BaseEditor.cs
+++ b/Runtime/Editor/BaseEditor.cs
@@ -25,7 +25,7 @@ namespace jp.ootr.common.Editor
         public virtual void OnEnable()
         {
             Root = new VisualElement();
-            Root.styleSheets.Add(styleSheet);
+            if (styleSheet != null) Root.styleSheets.Add(styleSheet);
             Root.AddToClassList("root");
             InfoBlock = new VisualElement();
             InfoBlock.AddToClassList("infoBlock");
@@ -81,10 +81,15 @@ namespace jp.ootr.common.Editor
 
         private void ShowUtilities()
         {
+            UtilitiesBlock.Clear();
             {
                 var colorPresetApplier = new Button(() =>
                 {
-                    ColorPresetApplier.ShowWindowWithTarget(target as BaseClass);
+                    var bc = target as BaseClass;
+                    if (bc != null)
+                        ColorPresetApplier.ShowWindowWithTarget(bc);
+                    else
+                        Debug.LogWarning("Target is not BaseClass.");
                 })
                 {
                     text = "ColorPresetApplier"
@@ -154,18 +159,26 @@ namespace jp.ootr.common.Editor
 
         public void OnProcessScene(Scene scene, BuildReport report)
         {
-            var classes = ComponentUtils.GetAllComponents<BaseClass>();
+            var rootObjects = scene.GetRootGameObjects();
 
-            foreach (var c in classes)
+            foreach (var rootObject in rootObjects)
             {
-                ColorSchemaUtils.ApplyColorSchemas(c);
-                LocalizationUtils.SetLocalizationReferences(c);
+                var baseClasses = rootObject.GetComponentsInChildren<BaseClass>(true);
+                foreach (var c in baseClasses)
+                {
+                    ColorSchemaUtils.ApplyColorSchemas(c);
+                    LocalizationUtils.SetLocalizationReferences(c);
+                }
             }
 
-            var editorOnlyComponents = Object.FindObjectsOfType<EditorOnlyMonoBehaviour>(true);
-            foreach (var component in editorOnlyComponents)
+            foreach (var rootObject in rootObjects)
             {
-                Object.DestroyImmediate(component);
+                var editorOnlyComponents = rootObject.GetComponentsInChildren<EditorOnlyMonoBehaviour>(true);
+                foreach (var component in editorOnlyComponents)
+                {
+                    if (component == null) continue;
+                    Object.DestroyImmediate(component);
+                }
             }
         }
     }
@@ -174,15 +187,22 @@ namespace jp.ootr.common.Editor
     {
         public static void ApplyColorSchemas(BaseClass target)
         {
-            if (target.colorSchemas.Length == 0 || target.colorSchemaNames.Length == 0) return;
+            if (target == null) return;
+            if (target.colorSchemas == null || target.colorSchemaNames == null ||
+                target.colorSchemas.Length == 0 || target.colorSchemaNames.Length == 0) return;
             var appliers = target.GetComponentsInChildren<ColorSchemaApplierBase>(true);
-            foreach (var applier in appliers) applier.ApplyColor(target.GetColor(applier.SchemaName));
+            foreach (var applier in appliers)
+            {
+                if (applier == null) continue;
+                applier.ApplyColor(target.GetColor(applier.SchemaName));
+            }
         }
 
         public static Color GetColor(this BaseClass target, string schemaName)
         {
-            if (target == null) return Color.white;
-            if (!target.colorSchemaNames.Has(schemaName, out var index)) return Color.white;
+            if (target == null || target.colorSchemas == null || target.colorSchemaNames == null) return Color.white;
+            if (string.IsNullOrEmpty(schemaName) || !target.colorSchemaNames.Has(schemaName, out var index)) return Color.white;
+            if (index < 0 || index >= target.colorSchemas.Length) return Color.white;
             return target.colorSchemas[index];
         }
 
@@ -207,15 +227,18 @@ namespace jp.ootr.common.Editor
     {
         public static void SetLocalizationReferences(BaseClass target)
         {
+            if (target == null) return;
             var targets = target.GetComponentsInChildren<LocalizationApplierTextMeshPro>(true);
             var baseClassSo = new SerializedObject(target);
             baseClassSo.Update();
             var localizationTargetKeys = baseClassSo.FindProperty(nameof(BaseClass.localizationTargetKeys));
             var localizationTargets = baseClassSo.FindProperty(nameof(BaseClass.localizationTargets));
+            if (localizationTargetKeys == null || localizationTargets == null) return;
             localizationTargetKeys.arraySize = targets.Length;
             localizationTargets.arraySize = targets.Length;
             for (var i = 0; i < targets.Length; i++)
             {
+                if (targets[i] == null) continue;
                 localizationTargetKeys.GetArrayElementAtIndex(i).stringValue = targets[i].TextKey;
                 localizationTargets.GetArrayElementAtIndex(i).objectReferenceValue = targets[i].TextMeshProUGUI;
             }

--- a/Runtime/Editor/BaseEditor.cs
+++ b/Runtime/Editor/BaseEditor.cs
@@ -176,13 +176,16 @@ namespace jp.ootr.common.Editor
                 }
             }
 
-            foreach (var rootObject in rootObjects)
+            if (report != null)
             {
-                var editorOnlyComponents = rootObject.GetComponentsInChildren<EditorOnlyMonoBehaviour>(true);
-                foreach (var component in editorOnlyComponents)
+                foreach (var rootObject in rootObjects)
                 {
-                    if (component == null) continue;
-                    Object.DestroyImmediate(component);
+                    var editorOnlyComponents = rootObject.GetComponentsInChildren<EditorOnlyMonoBehaviour>(true);
+                    foreach (var component in editorOnlyComponents)
+                    {
+                        if (component == null) continue;
+                        Object.DestroyImmediate(component);
+                    }
                 }
             }
         }

--- a/Runtime/Editor/BaseEditor.cs
+++ b/Runtime/Editor/BaseEditor.cs
@@ -160,8 +160,12 @@ namespace jp.ootr.common.Editor
             {
                 ColorSchemaUtils.ApplyColorSchemas(c);
                 LocalizationUtils.SetLocalizationReferences(c);
-                ColorSchemaUtils.DestroyColorAppliers(c);
-                LocalizationUtils.DestroyLocalizations(c);
+            }
+
+            var editorOnlyComponents = Object.FindObjectsOfType<EditorOnlyMonoBehaviour>(true);
+            foreach (var component in editorOnlyComponents)
+            {
+                Object.DestroyImmediate(component);
             }
         }
     }
@@ -173,12 +177,6 @@ namespace jp.ootr.common.Editor
             if (target.colorSchemas.Length == 0 || target.colorSchemaNames.Length == 0) return;
             var appliers = target.GetComponentsInChildren<ColorSchemaApplierBase>(true);
             foreach (var applier in appliers) applier.ApplyColor(target.GetColor(applier.SchemaName));
-        }
-
-        public static void DestroyColorAppliers(BaseClass target)
-        {
-            var appliers = target.GetComponentsInChildren<ColorSchemaApplierBase>(true);
-            foreach (var applier in appliers) Object.DestroyImmediate(applier);
         }
 
         public static Color GetColor(this BaseClass target, string schemaName)
@@ -225,11 +223,6 @@ namespace jp.ootr.common.Editor
             baseClassSo.ApplyModifiedProperties();
         }
 
-        public static void DestroyLocalizations(BaseClass target)
-        {
-            var appliers = target.GetComponentsInChildren<LocalizationApplierTextMeshPro>(true);
-            foreach (var applier in appliers) Object.DestroyImmediate(applier);
-        }
     }
 }
 #endif

--- a/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierBase.cs
+++ b/Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierBase.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace jp.ootr.common.ColorSchema
 {
-    public class ColorSchemaApplierBase : MonoBehaviour, IColorSchemaApplier
+    public class ColorSchemaApplierBase : EditorOnlyMonoBehaviour, IColorSchemaApplier
     {
         [SerializeField] protected string schemaName;
 

--- a/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs
+++ b/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs
@@ -1,0 +1,10 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+
+namespace jp.ootr.common
+{
+    public class EditorOnlyMonoBehaviour : MonoBehaviour
+    {
+    }
+}
+#endif

--- a/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs
+++ b/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace jp.ootr.common
 {
-    public class EditorOnlyMonoBehaviour : MonoBehaviour
+    public abstract class EditorOnlyMonoBehaviour : MonoBehaviour
     {
     }
 }

--- a/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs.meta
+++ b/Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c2f84a20619c16488c7a0667d4b5f90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
+++ b/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
@@ -9,12 +9,11 @@ namespace jp.ootr.common.Localization
     {
         [SerializeField] protected string textKey;
         public string TextKey => textKey;
-        public TextMeshProUGUI TextMeshProUGUI { get; private set; }
+        private TextMeshProUGUI _textMeshProUGUI;
 
-        private void Awake()
-        {
-            TextMeshProUGUI = GetComponent<TextMeshProUGUI>();
-        }
+        public TextMeshProUGUI TextMeshProUGUI => _textMeshProUGUI != null
+            ? _textMeshProUGUI
+            : (_textMeshProUGUI = GetComponent<TextMeshProUGUI>());
     }
 }
 #endif

--- a/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
+++ b/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
@@ -1,13 +1,15 @@
+#if UNITY_EDITOR
 using TMPro;
 using UnityEngine;
 
 namespace jp.ootr.common.Localization
 {
     [RequireComponent(typeof(TextMeshProUGUI))]
-    public class LocalizationApplierTextMeshPro : MonoBehaviour
+    public class LocalizationApplierTextMeshPro : EditorOnlyMonoBehaviour
     {
         [SerializeField] protected string textKey;
         public string TextKey => textKey;
         public TextMeshProUGUI TextMeshProUGUI => gameObject.GetComponent<TextMeshProUGUI>();
     }
 }
+#endif

--- a/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
+++ b/Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs
@@ -9,7 +9,12 @@ namespace jp.ootr.common.Localization
     {
         [SerializeField] protected string textKey;
         public string TextKey => textKey;
-        public TextMeshProUGUI TextMeshProUGUI => gameObject.GetComponent<TextMeshProUGUI>();
+        public TextMeshProUGUI TextMeshProUGUI { get; private set; }
+
+        private void Awake()
+        {
+            TextMeshProUGUI = GetComponent<TextMeshProUGUI>();
+        }
     }
 }
 #endif


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced editor stability with improved null safety checks and defensive validation during inspector setup.
  * Improved build-time scene processing to prevent editor-only components from appearing in built scenes.

* **Refactor**
  * Optimized editor-side caching for improved performance.
  * Streamlined build cleanup and component lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `EditorOnlyMonoBehaviour` as a unified base class for editor-only scene components (`ColorSchemaApplierBase`, `LocalizationApplierTextMeshPro`), and consolidates build-time destruction of those components into a single `DestroyImmediate` sweep inside `UnityBuildCallback.OnProcessScene`. Previously raised concerns — multi-scene scoping, play-mode destruction guard, and the `TextMeshProUGUI` lazy-init fallback — are all addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously identified P1 issues have been addressed and no new defects were found.

All three concerns raised in prior review threads (multi-scene scoping, play-mode destroy guard, TextMeshProUGUI pre-Awake null) are resolved in this revision. Null-safety guards were added throughout ColorSchemaUtils and LocalizationUtils, event subscription deduplication was added, and the Root.Bind/Unbind lifecycle in BaseEditor is now correct. No new P0 or P1 issues were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Runtime/jp.ootr.common/EditorOnlyMonoBehaviour.cs | New abstract marker base class, correctly guarded with #if UNITY_EDITOR so it only exists in editor compilations. |
| Runtime/jp.ootr.common/ColorSchema/ColorSchemaApplierBase.cs | Changed base class from MonoBehaviour to EditorOnlyMonoBehaviour; file is #if UNITY_EDITOR-guarded so compile-time safety is maintained. |
| Runtime/jp.ootr.common/Localization/LocalizationApplierTextMeshPro.cs | Now inherits from EditorOnlyMonoBehaviour and uses lazy-init GetComponent fallback for TextMeshProUGUI, correctly addressing the pre-Awake null issue during OnProcessScene. |
| Runtime/Editor/BaseEditor.cs | Multiple improvements: scene-scoped destruction, report != null guard for play-mode safety, Root.Bind/Unbind lifecycle, event deduplication, and null-safety throughout ApplyColorSchemas/SetLocalizationReferences. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Unity as Unity Build Pipeline
    participant UBC as UnityBuildCallback
    participant CSU as ColorSchemaUtils
    participant LU as LocalizationUtils
    participant EMB as EditorOnlyMonoBehaviour

    Unity->>UBC: OnProcessScene(scene, report)
    UBC->>UBC: scene.GetRootGameObjects()
    loop Each root object
        UBC->>CSU: ApplyColorSchemas(baseClass)
        CSU->>EMB: applier.ApplyColor(color)
        UBC->>LU: SetLocalizationReferences(baseClass)
        LU->>EMB: filteredTarget.TextMeshProUGUI (lazy GetComponent)
    end
    alt report != null (real build)
        loop Each root object
            UBC->>EMB: Object.DestroyImmediate(component)
        end
    end
    Note over EMB: Editor-only components removed from built scene
```

<sub>Reviews (6): Last reviewed commit: ["EditorOnlyMonoBehaviourを抽象化して誤アタッチを防止"](https://github.com/o-tr/jp.ootr.common/commit/8d45674a9305567a1e7c95b498b791b38e6e7a49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29987198)</sub>

<!-- /greptile_comment -->